### PR TITLE
Remove stale TODO in VM runner (Poseidon2 reuse via OnceLock)

### DIFF
--- a/crates/vm/src/runner.rs
+++ b/crates/vm/src/runner.rs
@@ -185,7 +185,7 @@ fn execute_bytecode_helper(
     profiler: bool,
     function_locations: &BTreeMap<usize, String>,
 ) -> Result<ExecutionResult, RunnerError> {
-    let poseidon_16 = get_poseidon16(); // TODO avoid rebuilding each time
+    let poseidon_16 = get_poseidon16();
     let poseidon_24 = get_poseidon24();
 
     // set public memory


### PR DESCRIPTION
**Summary**
- Remove an outdated TODO comment in `crates/vm/src/runner.rs` about “avoid rebuilding each time”.
- No functional changes.

**Context**
- `utils::get_poseidon16()` and `utils::get_poseidon24()` already cache instances using `OnceLock` in `crates/utils/src/poseidon2.rs`.
- The TODO suggested repeated construction, which is no longer the case, so the comment was misleading.

**What Changed**
- Deleted the stale comment at `crates/vm/src/runner.rs` near the `get_poseidon16()` and `get_poseidon24()` calls.