### PR TITLE
compiler: make Label an enum

### DIFF
--- a/crates/lean_compiler/src/c_compile_final.rs
+++ b/crates/lean_compiler/src/c_compile_final.rs
@@ -37,9 +37,9 @@ pub fn compile_to_low_level_bytecode(
     mut intermediate_bytecode: IntermediateBytecode,
 ) -> Result<Bytecode, String> {
     intermediate_bytecode.bytecode.insert(
-        "@end_program".to_string(),
+        Label::EndProgram,
         vec![IntermediateInstruction::Jump {
-            dest: IntermediateValue::label("@end_program".to_string()),
+            dest: IntermediateValue::label(Label::EndProgram),
             updated_fp: None,
         }],
     );
@@ -50,10 +50,10 @@ pub fn compile_to_low_level_bytecode(
         .unwrap();
 
     let mut label_to_pc = BTreeMap::new();
-    label_to_pc.insert("@function_main".to_string(), 0);
+    label_to_pc.insert(Label::function("main"), 0);
     let entrypoint = intermediate_bytecode
         .bytecode
-        .remove("@function_main")
+        .remove(&Label::function("main"))
         .ok_or("No main function found in the compiled program")?;
 
     let mut code_blocks = vec![(0, entrypoint.clone())];
@@ -64,7 +64,7 @@ pub fn compile_to_low_level_bytecode(
         pc += count_real_instructions(instructions);
     }
 
-    let ending_pc = label_to_pc.get("@end_program").copied().unwrap();
+    let ending_pc = label_to_pc.get(&Label::EndProgram).copied().unwrap();
 
     let mut match_block_sizes = Vec::new();
     let mut match_first_block_starts = Vec::new();
@@ -168,9 +168,7 @@ fn compile_block(
                 })
                 .expect("Fatal: Unlabeled jump destination")
                 .clone(),
-            MemOrConstant::MemoryAfterFp { offset } => {
-                format!("fp+{offset}")
-            }
+            MemOrConstant::MemoryAfterFp { offset } => Label::custom(format!("fp+{offset}")),
         };
         let updated_fp = updated_fp
             .map(|fp| try_as_mem_or_fp(&fp).unwrap())
@@ -376,10 +374,16 @@ fn eval_constant_value(constant: &ConstantValue, compiler: &Compiler) -> usize {
         ConstantValue::PublicInputStart => PUBLIC_INPUT_START,
         ConstantValue::PointerToZeroVector => ZERO_VEC_PTR,
         ConstantValue::PointerToOneVector => ONE_VEC_PTR,
-        ConstantValue::FunctionSize { function_name } => *compiler
-            .memory_size_per_function
-            .get(function_name)
-            .unwrap_or_else(|| panic!("Function {function_name} not found in memory size map")),
+        ConstantValue::FunctionSize { function_name } => {
+            let func_name_str = match function_name {
+                Label::Function(name) => name,
+                _ => panic!("Expected function label, got: {function_name}"),
+            };
+            *compiler
+                .memory_size_per_function
+                .get(func_name_str)
+                .unwrap_or_else(|| panic!("Function {func_name_str} not found in memory size map"))
+        }
         ConstantValue::Label(label) => compiler.label_to_pc.get(label).copied().unwrap(),
         ConstantValue::MatchBlockSize { match_index } => compiler.match_block_sizes[*match_index],
         ConstantValue::MatchFirstBlockStart { match_index } => {

--- a/crates/lean_vm/src/core/label.rs
+++ b/crates/lean_vm/src/core/label.rs
@@ -1,0 +1,203 @@
+/// Structured label for bytecode locations
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Label {
+    /// Function entry point: @function_{name}
+    Function(String),
+    /// Program termination: @end_program
+    EndProgram,
+    /// Conditional flow: @if_{id}, @else_{id}, @if_else_end_{id}
+    If { id: usize, kind: IfKind },
+    /// Match statement end: @match_end_{id}
+    MatchEnd(usize),
+    /// Return from function call: @return_from_call_{id}
+    ReturnFromCall(usize),
+    /// Loop definition: @loop_{id}
+    Loop(usize),
+    /// Built-in memory symbols
+    BuiltinSymbol(BuiltinSymbol),
+    /// Auxiliary variables during compilation
+    AuxVar { kind: AuxKind, id: usize },
+    /// Custom/raw label for backwards compatibility or special cases
+    Custom(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum IfKind {
+    /// @if_{id}
+    If,
+    /// @else_{id}
+    Else,
+    /// @if_else_end_{id}
+    End,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum BuiltinSymbol {
+    /// @public_input_start
+    PublicInputStart,
+    /// @pointer_to_zero_vector
+    PointerToZeroVector,
+    /// @pointer_to_one_vector
+    PointerToOneVector,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum AuxKind {
+    /// @aux_var_{id}
+    AuxVar,
+    /// @arr_aux_{id}
+    ArrayAux,
+    /// @diff_{id}
+    Diff,
+    /// @inlined_var_{count}_{var}
+    InlinedVar { count: usize, var: String },
+    /// @unrolled_{index}_{value}_{var}
+    UnrolledVar {
+        index: usize,
+        value: usize,
+        var: String,
+    },
+    /// @incremented_{var}
+    Incremented(String),
+    /// @trash_{id}
+    Trash,
+}
+
+impl std::fmt::Display for Label {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Function(name) => write!(f, "@function_{name}"),
+            Self::EndProgram => write!(f, "@end_program"),
+            Self::If { id, kind } => match kind {
+                IfKind::If => write!(f, "@if_{id}"),
+                IfKind::Else => write!(f, "@else_{id}"),
+                IfKind::End => write!(f, "@if_else_end_{id}"),
+            },
+            Self::MatchEnd(id) => write!(f, "@match_end_{id}"),
+            Self::ReturnFromCall(id) => write!(f, "@return_from_call_{id}"),
+            Self::Loop(id) => write!(f, "@loop_{id}"),
+            Self::BuiltinSymbol(symbol) => write!(f, "{symbol}"),
+            Self::AuxVar { kind, id } => match kind {
+                AuxKind::AuxVar => write!(f, "@aux_var_{id}"),
+                AuxKind::ArrayAux => write!(f, "@arr_aux_{id}"),
+                AuxKind::Diff => write!(f, "@diff_{id}"),
+                AuxKind::InlinedVar { count, var } => write!(f, "@inlined_var_{count}_{var}"),
+                AuxKind::UnrolledVar { index, value, var } => {
+                    write!(f, "@unrolled_{index}_{value}_{var}")
+                }
+                AuxKind::Incremented(var) => write!(f, "@incremented_{var}"),
+                AuxKind::Trash => write!(f, "@trash_{id}"),
+            },
+            Self::Custom(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+impl std::fmt::Display for BuiltinSymbol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PublicInputStart => write!(f, "@public_input_start"),
+            Self::PointerToZeroVector => write!(f, "@pointer_to_zero_vector"),
+            Self::PointerToOneVector => write!(f, "@pointer_to_one_vector"),
+        }
+    }
+}
+
+impl Label {
+    pub fn function(name: impl Into<String>) -> Self {
+        Self::Function(name.into())
+    }
+
+    pub fn if_label(id: usize) -> Self {
+        Self::If {
+            id,
+            kind: IfKind::If,
+        }
+    }
+
+    pub fn else_label(id: usize) -> Self {
+        Self::If {
+            id,
+            kind: IfKind::Else,
+        }
+    }
+
+    pub fn if_else_end(id: usize) -> Self {
+        Self::If {
+            id,
+            kind: IfKind::End,
+        }
+    }
+
+    pub fn match_end(id: usize) -> Self {
+        Self::MatchEnd(id)
+    }
+
+    pub fn return_from_call(id: usize) -> Self {
+        Self::ReturnFromCall(id)
+    }
+
+    pub fn loop_label(id: usize) -> Self {
+        Self::Loop(id)
+    }
+
+    pub fn aux_var(id: usize) -> Self {
+        Self::AuxVar {
+            kind: AuxKind::AuxVar,
+            id,
+        }
+    }
+
+    pub fn array_aux(id: usize) -> Self {
+        Self::AuxVar {
+            kind: AuxKind::ArrayAux,
+            id,
+        }
+    }
+
+    pub fn diff(id: usize) -> Self {
+        Self::AuxVar {
+            kind: AuxKind::Diff,
+            id,
+        }
+    }
+
+    pub fn inlined_var(count: usize, var: impl Into<String>) -> Self {
+        Self::AuxVar {
+            kind: AuxKind::InlinedVar {
+                count,
+                var: var.into(),
+            },
+            id: 0, // Not used for this variant
+        }
+    }
+
+    pub fn unrolled_var(index: usize, value: usize, var: impl Into<String>) -> Self {
+        Self::AuxVar {
+            kind: AuxKind::UnrolledVar {
+                index,
+                value,
+                var: var.into(),
+            },
+            id: 0, // Not used for this variant
+        }
+    }
+
+    pub fn incremented(var: impl Into<String>) -> Self {
+        Self::AuxVar {
+            kind: AuxKind::Incremented(var.into()),
+            id: 0, // Not used for this variant
+        }
+    }
+
+    pub fn trash(id: usize) -> Self {
+        Self::AuxVar {
+            kind: AuxKind::Trash,
+            id,
+        }
+    }
+
+    pub fn custom(label: impl Into<String>) -> Self {
+        Self::Custom(label.into())
+    }
+}

--- a/crates/lean_vm/src/core/mod.rs
+++ b/crates/lean_vm/src/core/mod.rs
@@ -1,5 +1,7 @@
 pub mod constants;
+pub mod label;
 pub mod types;
 
 pub use constants::*;
+pub use label::*;
 pub use types::*;

--- a/crates/lean_vm/src/core/types.rs
+++ b/crates/lean_vm/src/core/types.rs
@@ -9,8 +9,5 @@ pub type EF = QuinticExtensionFieldKB;
 /// Location in source code for debugging
 pub type SourceLineNumber = usize;
 
-/// String label for bytecode locations
-pub type Label = String;
-
 /// Bytecode address (i.e., a value of the program counter)
 pub type CodeAddress = usize;


### PR DESCRIPTION
Should close https://github.com/leanEthereum/leanMultisig/issues/58

@TomWambsgans I think that `Label` is defined in the leanvm crate to avoid circular dependencies because we are using it here for debugging purposes but in the future this should be migrated to the compiler crate, what do you think?