### PR TITLE
perf: add thin link-time optimization to `release` profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,9 @@ multilinear-toolkit.workspace = true
 criterion = { version = "0.7", default-features = false, features = ["cargo_bench_support"] }
 rec_aggregation.workspace = true
 
+[profile.release]
+lto = "thin"
+
 [[bench]]
 name = "poseidon2"
 harness = false


### PR DESCRIPTION
Has barely no impact on compilation time but improves running time non-negligibly.

On my M4 pro, I am getting for the Poseidon2 examples a bump in throughput from 381K / s to 403K / s on average ( + 5.7%)