### PR TITLE
Issue #76: Boolean expressions in conditional statements

### DIFF
--- a/crates/lean_compiler/src/b_compile_intermediate.rs
+++ b/crates/lean_compiler/src/b_compile_intermediate.rs
@@ -184,6 +184,21 @@ fn compile_lines(
                 }
             }
 
+            SimpleLine::TestZero {
+                operation,
+                arg0,
+                arg1,
+            } => {
+                instructions.push(IntermediateInstruction::computation(
+                    *operation,
+                    IntermediateValue::from_simple_expr(arg0, compiler),
+                    IntermediateValue::from_simple_expr(arg1, compiler),
+                    IntermediateValue::Constant(0.into()),
+                ));
+
+                mark_vars_as_declared(&[arg0, arg1], declared_vars);
+            }
+
             SimpleLine::Match { value, arms } => {
                 let match_index = compiler.match_blocks.len();
                 let end_label = Label::match_end(match_index);
@@ -768,6 +783,7 @@ fn find_internal_vars(lines: &[SimpleLine]) -> BTreeSet<Var> {
                     internal_vars.insert(var.clone());
                 }
             }
+            SimpleLine::TestZero { .. } => {}
             SimpleLine::HintMAlloc { var, .. }
             | SimpleLine::ConstMalloc { var, .. }
             | SimpleLine::DecomposeBits { var, .. }

--- a/crates/lean_compiler/src/grammar.pest
+++ b/crates/lean_compiler/src/grammar.pest
@@ -40,9 +40,9 @@ array_assign = { identifier ~ "[" ~ expression ~ "]" ~ "=" ~ expression ~ ";" }
 
 if_statement = { "if" ~ condition ~ "{" ~ statement* ~ "}" ~ else_clause? }
 
-condition = {condition_eq | condition_diff}
-condition_eq = { expression ~ "==" ~ expression }
-condition_diff = { expression ~ "!=" ~ expression }
+condition = { expression | assumed_bool_expr }
+
+assumed_bool_expr = { "!!assume_bool" ~ "(" ~ expression ~ ")" }
 
 else_clause = { "else" ~ "{" ~ statement* ~ "}" }
 
@@ -58,12 +58,14 @@ function_call = { function_res? ~ identifier ~ "(" ~ tuple_expression? ~ ")" ~ "
 function_res = { var_list ~ "=" }
 var_list = { identifier ~ ("," ~ identifier)* }
 
-assert_eq_statement = { "assert" ~ expression ~ "==" ~ expression ~ ";" }
-assert_not_eq_statement = { "assert" ~ expression ~ "!=" ~ expression ~ ";" }
+assert_eq_statement = { "assert" ~ add_expr ~ "==" ~ add_expr ~ ";" }
+assert_not_eq_statement = { "assert" ~ add_expr ~ "!=" ~ add_expr ~ ";" }
 
 // Expressions
 tuple_expression = { expression ~ ("," ~ expression)* }
-expression = { add_expr }
+expression = { neq_expr }
+neq_expr = { eq_expr ~ ("!=" ~ eq_expr)* }
+eq_expr = { add_expr ~ ("==" ~ add_expr)* }
 add_expr = { sub_expr ~ ("+" ~ sub_expr)* }
 sub_expr = { mul_expr ~ ("-" ~ mul_expr)* }
 mul_expr = { mod_expr ~ ("*" ~ mod_expr)* }

--- a/crates/lean_compiler/src/ir/instruction.rs
+++ b/crates/lean_compiler/src/ir/instruction.rs
@@ -120,7 +120,10 @@ impl IntermediateInstruction {
                 arg_c,
                 res: arg_a,
             },
-            HighLevelOperation::Exp | HighLevelOperation::Mod => unreachable!(),
+            HighLevelOperation::Exp
+            | HighLevelOperation::Mod
+            | HighLevelOperation::Equal
+            | HighLevelOperation::NotEqual => unreachable!(),
         }
     }
 

--- a/crates/lean_compiler/src/ir/operation.rs
+++ b/crates/lean_compiler/src/ir/operation.rs
@@ -23,11 +23,29 @@ pub enum HighLevelOperation {
     Exp,
     /// Modulo operation (only for constant expressions).
     Mod,
+    /// Equality comparison
+    Equal,
+    /// Non-equality comparison
+    NotEqual,
 }
 
 impl HighLevelOperation {
     pub fn eval(&self, a: F, b: F) -> F {
         match self {
+            Self::Equal => {
+                if a == b {
+                    F::ONE
+                } else {
+                    F::ZERO
+                }
+            }
+            Self::NotEqual => {
+                if a != b {
+                    F::ONE
+                } else {
+                    F::ZERO
+                }
+            }
             Self::Add => a + b,
             Self::Mul => a * b,
             Self::Sub => a - b,
@@ -41,6 +59,8 @@ impl HighLevelOperation {
 impl Display for HighLevelOperation {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::Equal => write!(f, "=="),
+            Self::NotEqual => write!(f, "!="),
             Self::Add => write!(f, "+"),
             Self::Mul => write!(f, "*"),
             Self::Sub => write!(f, "-"),

--- a/crates/lean_compiler/src/lang.rs
+++ b/crates/lean_compiler/src/lang.rs
@@ -222,6 +222,30 @@ impl From<ConstantValue> for ConstExpression {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum AssumeBoolean {
+    AssumeBoolean,
+    DoNotAssumeBoolean,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Condition {
+    Expression(Expression, AssumeBoolean),
+    Comparison(Boolean),
+}
+
+impl Display for Condition {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Expression(expr, AssumeBoolean::AssumeBoolean) => {
+                write!(f, "!assume_bool({expr})")
+            }
+            Self::Expression(expr, AssumeBoolean::DoNotAssumeBoolean) => write!(f, "{expr}"),
+            Self::Comparison(cmp) => write!(f, "{cmp}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Expression {
     Value(SimpleExpr),
     ArrayAccess {
@@ -310,7 +334,7 @@ pub enum Line {
     },
     Assert(Boolean),
     IfCondition {
-        condition: Boolean,
+        condition: Condition,
         then_branch: Vec<Self>,
         else_branch: Vec<Self>,
     },

--- a/crates/lean_compiler/src/parser/parsers/expression.rs
+++ b/crates/lean_compiler/src/parser/parsers/expression.rs
@@ -4,7 +4,7 @@ use crate::{
     ir::HighLevelOperation,
     lang::Expression,
     parser::{
-        error::{ParseResult, SemanticError},
+        error::{ParseError, ParseResult, SemanticError},
         grammar::{ParsePair, Rule},
     },
 };
@@ -18,6 +18,12 @@ impl Parse<Expression> for ExpressionParser {
             Rule::expression => {
                 let inner = next_inner_pair(&mut pair.into_inner(), "expression body")?;
                 Self::parse(inner, ctx)
+            }
+            Rule::neq_expr => {
+                BinaryExpressionParser::parse_with_op(pair, ctx, HighLevelOperation::NotEqual)
+            }
+            Rule::eq_expr => {
+                BinaryExpressionParser::parse_with_op(pair, ctx, HighLevelOperation::Equal)
             }
             Rule::add_expr => {
                 BinaryExpressionParser::parse_with_op(pair, ctx, HighLevelOperation::Add)
@@ -38,7 +44,9 @@ impl Parse<Expression> for ExpressionParser {
                 BinaryExpressionParser::parse_with_op(pair, ctx, HighLevelOperation::Exp)
             }
             Rule::primary => PrimaryExpressionParser::parse(pair, ctx),
-            _ => Err(SemanticError::new("Invalid expression").into()),
+            other_rule => Err(ParseError::SemanticError(SemanticError::new(format!(
+                "ExpressionParser: Unexpected rule {other_rule:?}"
+            )))),
         }
     }
 }

--- a/crates/lean_compiler/tests/test_compiler.rs
+++ b/crates/lean_compiler/tests/test_compiler.rs
@@ -278,7 +278,7 @@ fn test_mini_program_2() {
             for j in i..10 {
                 for k in j..10 {
                     sum, prod = compute_sum_and_product(i, j, k);
-                    if sum == 10 {
+                    if (sum == 10) {
                         print(i, j, k, prod);
                     }
                 }

--- a/crates/lean_prover/tests/hash_chain.rs
+++ b/crates/lean_prover/tests/hash_chain.rs
@@ -101,7 +101,7 @@ fn benchmark_poseidon_chain() {
         display_logs: true,
     });
 
-    println!("VM proof time: {:?}", vm_time);
+    println!("VM proof time: {vm_time:?}");
     println!("Raw Poseidon proof time: {:?}", raw_proof.prover_time);
 
     println!(

--- a/crates/packed_pcs/src/lib.rs
+++ b/crates/packed_pcs/src/lib.rs
@@ -99,10 +99,7 @@ fn split_in_chunks<F: Field>(
     if let Some(log_public) = dims.log_public_data_size {
         assert!(
             log_public >= log_smallest_decomposition_chunk,
-            "poly {}: {} < {}",
-            poly_index,
-            log_public,
-            log_smallest_decomposition_chunk
+            "poly {poly_index}: {log_public} < {log_smallest_decomposition_chunk}"
         );
         res.push(Chunk {
             original_poly_index: poly_index,

--- a/crates/rec_aggregation/src/xmss_aggregate.rs
+++ b/crates/rec_aggregation/src/xmss_aggregate.rs
@@ -43,7 +43,7 @@ pub fn run_xmss_benchmark(n_xmss: usize) -> XmssBenchStats {
         bitield = public_input_start + (2 + N_PUBLIC_KEYS) * 8;
         signatures_start = private_input_start / 8;
         for i in 0..N_PUBLIC_KEYS {
-            if bitield[i] == 1 {
+            if !!assume_bool(bitield[i]) {
                 xmss_public_key = all_public_keys + i;
 
                 sig_index = counter_hint();


### PR DESCRIPTION
Closes #76 .

These changes save exactly 1,000 cycles for the 500 XMSS aggregation test, while reducing bytecode size by 1 and leaving memory usage the same.

These changes make it the XMSS aggregation verifier's responsibility to ensure that the `bitield` values in the public input are in fact bits.

Unfortunately, the most frequent usage of the `if X == 1` idiom in the XMSS aggregation test were not apparently in a context where `X` can be assumed to be boolean. This is in the condition `if merkle_are_left[h] == 1`. Changing this to `if merkle_are_left[h]` resulted in an increased cycle count. Changing this to `if !!assume_bool(merkle_are_left[h])` resulted in a more substantially decreased cycle count, but I expect it also would give up soundness.

These changes increase the cycle count by 12 for the WHIR recursion test, while leaving bytecode size and memory usage the same.

I don't know why these changes increase the cycle count by 12 for the WHIR recursion test. I did find usages of the `if X == 1` idiom in the WHIR recursion test where `X` could safely be assumed to be boolean, but for whatever reason, replacing these instances with `if !!assume_bool(X)` resulted in an increased cycle count.