### PR TITLE
fix: export XmssSignature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub use xmss::{
     XMSS_MIN_LOG_LIFETIME,
     XmssPublicKey,
     XmssSecretKey,
+    XmssSignature,
     xmss_generate_phony_signatures, // useful for tests
     xmss_key_gen,
     xmss_sign,


### PR DESCRIPTION
I was unable to call XmssSignature Struct In ream