### PR TITLE
fix: add canonical range check to MontyField31 deserialization

### DIFF
--- a/crates/backend/koala-bear/src/monty_31/monty_31.rs
+++ b/crates/backend/koala-bear/src/monty_31/monty_31.rs
@@ -160,6 +160,9 @@ impl<'de, FP: FieldParameters> Deserialize<'de> for MontyField31<FP> {
     fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
         // It's faster to Serialize and Deserialize in monty form.
         let val = u32::deserialize(d)?;
+        if val >= FP::PRIME {
+            return Err(serde::de::Error::custom("non-canonical MontyField31 value"));
+        }
         Ok(Self::new_monty(val))
     }
 }


### PR DESCRIPTION
## Summary

**Severity: CRITICAL (F-01)**

The `Deserialize` impl for `MontyField31` at `crates/backend/koala-bear/src/monty_31/monty_31.rs:159-164` accepts any `u32` and passes it directly to `new_monty()` without verifying `val < PRIME`. An attacker can craft a serialized value >= `FP::PRIME` that gets stored as-is in Montgomery form, creating a non-canonical field element.

This breaks the field invariant (`value < P`) and can cause:
- Incorrect field arithmetic (addition, multiplication produce wrong results)
- Forged proofs accepted by verifiers
- Consensus divergence between nodes that check canonicality and those that do not

## Fix

Add a range check before `new_monty()`:

```rust
if val >= FP::PRIME {
    return Err(serde::de::Error::custom("non-canonical MontyField31 value"));
}
```

## Test plan

- [ ] Verify existing tests pass (serialization round-trip still works for canonical values)
- [ ] Verify that deserializing a value >= PRIME now returns an error
- [ ] Fuzz deserialization with random u32 values to confirm only canonical values are accepted

Found during security audit of leanEthereum repositories.