### PR TITLE
fix: deduplicate STIR query indices to preserve soundness

### DIFF
--- a/crates/whir/src/utils.rs
+++ b/crates/whir/src/utils.rs
@@ -21,7 +21,18 @@ pub(crate) fn get_challenge_stir_queries<F: Field, Chal: ChallengeSampler<F>>(
     num_queries: usize,
     challenger: &mut Chal,
 ) -> Vec<usize> {
-    challenger.sample_in_range(folded_domain_size.ilog2() as usize, num_queries)
+    let bits = folded_domain_size.ilog2() as usize;
+    let mut indices = Vec::with_capacity(num_queries);
+    let mut seen = std::collections::HashSet::with_capacity(num_queries);
+    while indices.len() < num_queries {
+        let batch = challenger.sample_in_range(bits, num_queries - indices.len());
+        for idx in batch {
+            if seen.insert(idx) {
+                indices.push(idx);
+            }
+        }
+    }
+    indices
 }
 
 /// A utility function to sample Out-of-Domain (OOD) points and evaluate them.


### PR DESCRIPTION
## Summary

**Severity: HIGH (F-02)**

`get_challenge_stir_queries` in `crates/whir/src/utils.rs:19-25` delegates directly to `challenger.sample_in_range(bits, num_queries)` which can return duplicate indices. When duplicate query indices occur, the effective number of distinct queries is reduced below the security parameter, weakening the soundness guarantee of the STIR protocol.

For example, if `num_queries` is 128 but only 120 unique indices are returned, the verifier performs ~8 fewer independent checks than the security parameter requires. With a small folded domain, the collision probability increases significantly (birthday paradox).

## Fix

Replace the single `sample_in_range` call with a deduplication loop that uses a `HashSet` to track seen indices and keeps sampling until exactly `num_queries` distinct indices are collected:

```rust
let bits = folded_domain_size.ilog2() as usize;
let mut indices = Vec::with_capacity(num_queries);
let mut seen = std::collections::HashSet::with_capacity(num_queries);
while indices.len() < num_queries {
    let batch = challenger.sample_in_range(bits, num_queries - indices.len());
    for idx in batch {
        if seen.insert(idx) {
            indices.push(idx);
        }
    }
}
indices
```

## Test plan

- [ ] Verify existing WHIR prover/verifier tests pass
- [ ] Test with small folded domain sizes where collisions are likely (e.g., domain_size=16, num_queries=8)
- [ ] Verify the returned Vec always has exactly `num_queries` elements, all distinct

Found during security audit of leanEthereum repositories.