### PR TITLE
fix: increase XMSS seed from 160 bits to 256 bits

### DIFF
--- a/crates/xmss/tests/xmss_tests.rs
+++ b/crates/xmss/tests/xmss_tests.rs
@@ -6,7 +6,7 @@ type F = KoalaBear;
 
 #[test]
 fn test_xmss_serialize_deserialize() {
-    let keygen_seed: [u8; 20] = std::array::from_fn(|i| i as u8);
+    let keygen_seed: [u8; 32] = std::array::from_fn(|i| i as u8);
     let message: [F; MESSAGE_LEN_FE] = std::array::from_fn(|i| F::from_usize(i * 3 + 7));
 
     let (sk, pk) = xmss_key_gen(keygen_seed, 100, 115).unwrap();
@@ -25,7 +25,7 @@ fn test_xmss_serialize_deserialize() {
 
 #[test]
 fn keygen_sign_verify() {
-    let keygen_seed: [u8; 20] = std::array::from_fn(|i| i as u8);
+    let keygen_seed: [u8; 32] = std::array::from_fn(|i| i as u8);
     let message: [F; MESSAGE_LEN_FE] = std::array::from_fn(|i| F::from_usize(i * 3 + 7));
 
     let (sk, pk) = xmss_key_gen(keygen_seed, 100, 115).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ mod tests {
         let start = 555;
         let end = 565;
         let slot = 560;
-        let key_gen_seed: [u8; 20] = rand::rng().random();
+        let key_gen_seed: [u8; 32] = rand::rng().random();
         let message_hash: [F; MESSAGE_LEN_FE] = std::array::from_fn(|i| F::from_usize(i * 3));
 
         let (secret_key, pub_key) = xmss_key_gen(key_gen_seed, start, end).unwrap();


### PR DESCRIPTION
## Summary

**Severity: HIGH (F-04)**

The XMSS secret key seed in `crates/xmss/src/xmss.rs:11` is `[u8; 20]` (160 bits), which provides only ~80 bits of security against brute-force search (birthday bound). This falls below the standard 128-bit security target for cryptographic schemes. An attacker with approximately 2^80 computation could recover the seed and forge signatures for any slot in the key's lifetime range.

## Fix

- Change `seed` field in `XmssSecretKey` from `[u8; 20]` to `[u8; 32]` (256 bits, providing 128-bit security margin)
- Update `xmss_key_gen()` parameter from `[u8; 20]` to `[u8; 32]`
- Update `gen_wots_secret_key()` and `gen_random_node()` to use XOR-based domain separation on the full 32-byte seed, replacing the previous concatenation scheme that relied on unused bytes at the end of the seed
- Update all test callers to use `[u8; 32]`

**BREAKING CHANGE**: `xmss_key_gen()` now takes `[u8; 32]` instead of `[u8; 20]`. The `XmssSecretKey` struct layout changes. Existing serialized keys are incompatible.

## Domain separation scheme

The previous approach concatenated the 20-byte seed with domain bytes in positions 20..32. With a full 32-byte seed, we instead XOR domain-specific tags into fixed positions:
- `gen_wots_secret_key`: XOR `0x57` ('W') at byte 0, slot at bytes 1..5
- `gen_random_node`: XOR `0x4E` ('N') at byte 0, level at byte 1, index at bytes 2..6

This ensures each derived sub-seed is unique per (domain, slot/level/index) while using all 256 bits of the master seed entropy.

## Test plan

- [ ] Verify existing tests pass with updated 32-byte seeds
- [ ] Verify key generation, signing, and verification still produce correct results
- [ ] Verify different seeds produce different keys (no collisions in derivation)
- [ ] Update downstream callers (`signers_cache.rs` uses `rng.random()` which auto-adapts to the new size)

Found during security audit of leanEthereum repositories.