### PR TITLE
perf: replace heap allocations with stack arrays in logup inner loops

### DIFF
--- a/crates/sub_protocols/src/logup.rs
+++ b/crates/sub_protocols/src/logup.rs
@@ -106,9 +106,7 @@ pub fn prove_generic_logup(
         if *table == Table::execution() {
             // 0] bytecode lookup
             let pc_column = &trace.base[COL_PC];
-            let bytecode_columns = trace.base[N_RUNTIME_COLUMNS..][..N_INSTRUCTION_COLUMNS]
-                .iter()
-                .collect::<Vec<_>>();
+            let bytecode_columns = &trace.base[N_RUNTIME_COLUMNS..][..N_INSTRUCTION_COLUMNS];
             numerators[offset..][..1 << log_n_rows].par_iter_mut().for_each(|num| {
                 *num = EF::ONE;
             }); // TODO embedding overhead
@@ -116,11 +114,11 @@ pub fn prove_generic_logup(
                 .par_iter_mut()
                 .enumerate()
                 .for_each(|(i, denom)| {
-                    let mut data = Vec::with_capacity(1 + N_INSTRUCTION_COLUMNS);
-                    for col in &bytecode_columns {
-                        data.push(col[i]);
+                    let mut data = [F::ZERO; N_INSTRUCTION_COLUMNS + 1];
+                    for j in 0..N_INSTRUCTION_COLUMNS {
+                        data[j] = bytecode_columns[j][i];
                     }
-                    data.push(pc_column[i]);
+                    data[N_INSTRUCTION_COLUMNS] = pc_column[i];
                     *denom = c - finger_print(F::from_usize(LOGUP_BYTECODE_DOMAINSEP), &data, alphas_eq_poly)
                 });
             offset += 1 << log_n_rows;
@@ -142,15 +140,16 @@ pub fn prove_generic_logup(
             .enumerate()
             .for_each(|(i, denom)| {
                 *denom = {
+                    let mut bus_data = [F::ZERO; N_INSTRUCTION_COLUMNS];
+                    for (j, entry) in bus.data.iter().enumerate() {
+                        bus_data[j] = match entry {
+                            BusData::Column(col) => trace.base[*col][i],
+                            BusData::Constant(val) => F::from_usize(*val),
+                        };
+                    }
                     c + finger_print(
                         F::from_usize(LOGUP_PRECOMPILE_DOMAINSEP),
-                        &bus.data
-                            .iter()
-                            .map(|entry| match entry {
-                                BusData::Column(col) => trace.base[*col][i],
-                                BusData::Constant(val) => F::from_usize(*val),
-                            })
-                            .collect::<Vec<_>>(),
+                        &bus_data[..bus.data.len()],
                         alphas_eq_poly,
                     )
                 }


### PR DESCRIPTION
Fixes #154.

Replaces two `Vec` heap allocations with stack-allocated fixed-size arrays in the hot inner loops of `prove_generic_logup`:

1. **Bytecode lookup denominator** (line 119): `Vec::with_capacity(1 + N_INSTRUCTION_COLUMNS)` → `[F::ZERO; N_INSTRUCTION_COLUMNS + 1]` — matching the existing pattern at lines 88-90.

2. **Bus denominator** (lines 147-153): `.collect::<Vec<_>>()` → `[F::ZERO; N_INSTRUCTION_COLUMNS]` with explicit length slice `&bus_data[..bus.data.len()]`. All bus data lengths are ≤ 4 (verified across all table implementations), well within the `N_INSTRUCTION_COLUMNS = 12` bound.

3. **Bytecode columns collection** (line 111): `.collect::<Vec<_>>()` → slice reference, avoiding an unnecessary `Vec` allocation.

These allocations occur inside `par_iter_mut().for_each()` closures, meaning they execute once per row of the trace — potentially millions of times. Stack arrays eliminate per-iteration allocator pressure and improve cache locality.