### PR TITLE
fix: cap slot range in xmss_key_gen to prevent unbounded memory allocation

### DIFF
--- a/crates/xmss/tests/xmss_tests.rs
+++ b/crates/xmss/tests/xmss_tests.rs
@@ -36,6 +36,21 @@ fn keygen_sign_verify() {
 }
 
 #[test]
+fn test_xmss_key_gen_range_too_large() {
+    let seed = [0u8; 20];
+    let result = xmss_key_gen(seed, 0, (1 << 20) + 1);
+    assert!(matches!(result, Err(XmssKeyGenError::RangeTooLarge)));
+}
+
+#[test]
+fn test_xmss_key_gen_max_range_ok() {
+    // Exactly MAX_SLOT_RANGE should be accepted (but may be slow, so use smaller range)
+    let seed = [0u8; 20];
+    let result = xmss_key_gen(seed, 0, 99);
+    assert!(result.is_ok());
+}
+
+#[test]
 #[ignore]
 fn encoding_grinding_bits() {
     let n = 100;


### PR DESCRIPTION
Fixes #133.

`xmss_key_gen` previously accepted any `(slot_start, slot_end)` range up to `2^32` slots, which could allocate tens of GiB for the Merkle tree (each leaf requires a WOTS key generation + hash). A malicious or accidental call with a large range would cause OOM.

This adds a `MAX_SLOT_RANGE` cap of `1 << 20` (~1M slots, ~32 MiB tree), returning a new `XmssKeyGenError::RangeTooLarge` error for ranges exceeding this limit. This cap is generous for practical use — with 12-second slots, 1M slots covers ~139 days of validator operation.

Changes:
- Added `RangeTooLarge` variant to `XmssKeyGenError`
- Added range check after existing `slot_start > slot_end` validation
- Added tests for the new error case