### PR TITLE
sort pubkeys in aggregate and verify

### DIFF
--- a/crates/rec_aggregation/src/lib.rs
+++ b/crates/rec_aggregation/src/lib.rs
@@ -195,9 +195,9 @@ pub fn xmss_verify_aggregation(
     message: &[u8; MESSAGE_LENGTH],
     slot: u32,
 ) -> Result<ProofVerificationDetails, ProofError> {
-    if !pub_keys.is_sorted() {
-        return Err(ProofError::InvalidProof);
-    }
+    let mut pub_keys = pub_keys;
+    pub_keys.sort();
+
     let public_input = agg_sig.public_input(&pub_keys, message, slot);
     let bytecode = get_aggregation_bytecode();
     verify_execution(bytecode, &public_input, agg_sig.proof.clone()).map(|(details, _)| details)
@@ -214,6 +214,15 @@ pub fn xmss_aggregate(
 ) -> (Vec<XmssPublicKey>, AggregatedXMSS) {
     raw_xmss.sort_by(|(a, _), (b, _)| a.cmp(b));
     raw_xmss.dedup_by(|(a, _), (b, _)| a == b);
+
+    let children: Vec<(Vec<XmssPublicKey>, &AggregatedXMSS)> = children
+        .iter()
+        .map(|&(pks, ref agg)| {
+            let mut v = pks.to_vec();
+            v.sort();
+            (v, agg)
+        })
+        .collect();
 
     let n_recursions = children.len();
     let raw_count = raw_xmss.len();
@@ -237,8 +246,8 @@ pub fn xmss_aggregate(
     let mut child_pub_inputs = vec![];
     let mut child_bytecode_evals = vec![];
     let mut child_raw_proofs = vec![];
-    for (child_pubkeys, child) in children {
-        let child_pub_input = child.public_input(child_pubkeys, message, slot);
+    for (child_pubkeys, child) in &children {
+        let child_pub_input = child.public_input(&child_pubkeys, message, slot);
         let (verif, raw_proof) = verify_execution(bytecode, &child_pub_input, child.proof.clone()).unwrap();
         child_bytecode_evals.push(verif.bytecode_evaluation);
         child_pub_inputs.push(child_pub_input);
@@ -357,9 +366,9 @@ pub fn xmss_aggregate(
     // Sources 1..n_recursions: recursive children
     for (i, (child_pubkeys, _)) in children.iter().enumerate() {
         let mut block = vec![F::from_usize(child_pubkeys.len())];
-        for pubkeykey in *child_pubkeys {
+        for pubkeykey in child_pubkeys {
             if claimed.insert(pubkeykey.clone()) {
-                let pos = global_pub_keys.binary_search(pubkeykey).unwrap();
+                let pos = global_pub_keys.binary_search(&pubkeykey).unwrap();
                 block.push(F::from_usize(pos));
             } else {
                 block.push(F::from_usize(n_sigs + dup_pub_keys.len()));


### PR DESCRIPTION
pubkeys are stored via validator index , although sorting is doable at clients end it isn't an implementation detail clients need to really take care of