### PR TITLE
benchmark: expose per-node aggregation metrics

### DIFF
--- a/crates/rec_aggregation/src/benchmark.rs
+++ b/crates/rec_aggregation/src/benchmark.rs
@@ -32,11 +32,16 @@ pub struct NodeReport {
     pub stats: NodeStats,
 }
 
-/// Per-node metrics in tree-walk order, plus the total wall time.
+/// Per-node metrics in tree-walk order.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BenchmarkReport {
-    pub total_time_secs: f64,
     pub nodes: Vec<NodeReport>,
+}
+
+impl BenchmarkReport {
+    pub fn total_time_secs(&self) -> f64 {
+        self.nodes.iter().map(|n| n.stats.time_secs).sum()
+    }
 }
 
 struct LiveTree {
@@ -239,7 +244,7 @@ fn build_aggregation(
     signatures: &[XmssSignature],
     overlap: usize,
     tracing: bool,
-) -> (Vec<XmssPublicKey>, AggregatedXMSS, f64) {
+) -> (Vec<XmssPublicKey>, AggregatedXMSS) {
     let raw_count = topology.raw_xmss;
     let raw_xmss: Vec<(XmssPublicKey, XmssSignature)> = (0..raw_count)
         .map(|i| (pub_keys[i].clone(), signatures[i].clone()))
@@ -252,7 +257,7 @@ fn build_aggregation(
     for (child_idx, child) in topology.children.iter().enumerate() {
         let child_count = count_signers(child, overlap);
         path.push(child_idx);
-        let (child_pks, child_agg, _) = build_aggregation(
+        let (child_pks, child_agg) = build_aggregation(
             child,
             child_display_index,
             nodes,
@@ -335,7 +340,7 @@ fn build_aggregation(
         stats,
     });
 
-    (global_pub_keys, result, elapsed.as_secs_f64())
+    (global_pub_keys, result)
 }
 
 pub fn run_aggregation_benchmark(
@@ -381,7 +386,7 @@ pub fn run_aggregation_benchmark(
 
     let mut nodes: Vec<NodeReport> = Vec::new();
     let mut path: Vec<usize> = Vec::new();
-    let (global_pub_keys, aggregated_sigs, total_time_secs) = build_aggregation(
+    let (global_pub_keys, aggregated_sigs) = build_aggregation(
         topology,
         0,
         &mut nodes,
@@ -402,7 +407,7 @@ pub fn run_aggregation_benchmark(
     )
     .unwrap();
 
-    BenchmarkReport { total_time_secs, nodes }
+    BenchmarkReport { nodes }
 }
 
 // TODO is there a better fix?
@@ -458,7 +463,7 @@ fn test_aggregation_throughput_per_num_xmss() {
             children: vec![],
             log_inv_rate,
         };
-        let time = run_aggregation_benchmark(&topology, 0, false, true).total_time_secs;
+        let time = run_aggregation_benchmark(&topology, 0, false, true).total_time_secs();
         num_xmss_and_time.push((num_xmss, time));
         println!(
             "{} XMSS -> {} XMSS/s",

--- a/crates/rec_aggregation/src/benchmark.rs
+++ b/crates/rec_aggregation/src/benchmark.rs
@@ -326,8 +326,6 @@ fn build_aggregation(
         dots: meta.n_extension_ops,
         n_xmss: if is_leaf { Some(topology.raw_xmss) } else { None },
     };
-    // LiveTree shares stdout with `tracing-forest`; only paint when tracing
-    // is off. (silent mode is handled inside `update_node`.)
     if !tracing {
         let own_display_index = display_index + count_nodes(topology) - 1;
         live_tree.update_node(own_display_index, &stats);

--- a/crates/rec_aggregation/src/benchmark.rs
+++ b/crates/rec_aggregation/src/benchmark.rs
@@ -25,14 +25,18 @@ pub struct NodeStats {
     pub n_xmss: Option<usize>,
 }
 
+/// `path` is the topology-relative path from the root (`[]` = root)
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NodeReport {
+    pub path: Vec<usize>,
+    pub stats: NodeStats,
+}
+
 /// Per-node metrics in tree-walk order, plus the total wall time.
-///
-/// `nodes[i].0` is the topology-relative path from the root (`[]` = root);
-/// each element is a child index into its parent's `children` vec.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BenchmarkReport {
     pub total_time_secs: f64,
-    pub nodes: Vec<(Vec<usize>, NodeStats)>,
+    pub nodes: Vec<NodeReport>,
 }
 
 struct LiveTree {
@@ -132,8 +136,8 @@ impl LiveTree {
         io::stdout().flush().unwrap();
     }
 
-    fn update_node(&mut self, index: usize, stats: NodeStats) {
-        self.statuses[index] = Some(stats);
+    fn update_node(&mut self, index: usize, stats: &NodeStats) {
+        self.statuses[index] = Some(stats.clone());
         if self.silent {
             return;
         }
@@ -228,7 +232,7 @@ fn build_tree_descs(
 fn build_aggregation(
     topology: &AggregationTopology,
     display_index: usize,
-    nodes: &mut Vec<(Vec<usize>, NodeStats)>,
+    nodes: &mut Vec<NodeReport>,
     live_tree: &mut LiveTree,
     path: &mut Vec<usize>,
     pub_keys: &[XmssPublicKey],
@@ -296,10 +300,13 @@ fn build_aggregation(
     };
 
     let elapsed = time.elapsed();
+    let meta = result.metadata.as_ref().unwrap();
+    let proof_kib = result.proof.proof_size_fe() * F::bits() / (8 * 1024);
+    let is_leaf = topology.children.is_empty();
 
     if tracing {
-        println!("{}", result.metadata.as_ref().unwrap().display());
-        if topology.children.is_empty() {
+        println!("{}", meta.display());
+        if is_leaf {
             println!(
                 "{} XMSS/s",
                 (topology.raw_xmss as f64 / elapsed.as_secs_f64()).round() as usize
@@ -307,30 +314,25 @@ fn build_aggregation(
         } else {
             println!("{:.3}s the final aggregation step", elapsed.as_secs_f64());
         }
-        println!(
-            "Proof size: {} KiB",
-            result.proof.proof_size_fe() * F::bits() / (8 * 1024)
-        );
+        println!("Proof size: {} KiB", proof_kib);
     }
 
-    let own_display_index = display_index + count_nodes(topology) - 1;
-    let proof_kib = result.proof.proof_size_fe() * F::bits() / (8 * 1024);
-    let is_leaf = topology.children.is_empty();
     let stats = NodeStats {
         time_secs: elapsed.as_secs_f64(),
         proof_kib,
-        cycles: result.metadata.as_ref().unwrap().cycles,
-        memory: result.metadata.as_ref().unwrap().memory,
-        poseidons: result.metadata.as_ref().unwrap().n_poseidons,
-        dots: result.metadata.as_ref().unwrap().n_extension_ops,
+        cycles: meta.cycles,
+        memory: meta.memory,
+        poseidons: meta.n_poseidons,
+        dots: meta.n_extension_ops,
         n_xmss: if is_leaf { Some(topology.raw_xmss) } else { None },
     };
-    nodes.push((path.clone(), stats.clone()));
     // LiveTree shares stdout with `tracing-forest`; only paint when tracing
     // is off. (silent mode is handled inside `update_node`.)
     if !tracing {
-        live_tree.update_node(own_display_index, stats);
+        let own_display_index = display_index + count_nodes(topology) - 1;
+        live_tree.update_node(own_display_index, &stats);
     }
+    nodes.push(NodeReport { path: path.clone(), stats });
 
     (global_pub_keys, result, elapsed.as_secs_f64())
 }
@@ -376,7 +378,7 @@ pub fn run_aggregation_benchmark(
         display.print_initial();
     }
 
-    let mut nodes: Vec<(Vec<usize>, NodeStats)> = Vec::new();
+    let mut nodes: Vec<NodeReport> = Vec::new();
     let mut path: Vec<usize> = Vec::new();
     let (global_pub_keys, aggregated_sigs, total_time_secs) = build_aggregation(
         topology,

--- a/crates/rec_aggregation/src/benchmark.rs
+++ b/crates/rec_aggregation/src/benchmark.rs
@@ -1,5 +1,6 @@
 use backend::*;
 use lean_vm::*;
+use serde::{Deserialize, Serialize};
 use std::io::{self, Write};
 use std::time::Instant;
 use utils::ansi as s;
@@ -13,15 +14,25 @@ fn count_nodes(topology: &AggregationTopology) -> usize {
     1 + topology.children.iter().map(count_nodes).sum::<usize>()
 }
 
-#[derive(Clone)]
-struct NodeStats {
-    time_secs: f64,
-    proof_kib: usize,
-    cycles: usize,
-    memory: usize,
-    poseidons: usize,
-    dots: usize,
-    n_xmss: Option<usize>,
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NodeStats {
+    pub time_secs: f64,
+    pub proof_kib: usize,
+    pub cycles: usize,
+    pub memory: usize,
+    pub poseidons: usize,
+    pub dots: usize,
+    pub n_xmss: Option<usize>,
+}
+
+/// Per-node metrics in tree-walk order, plus the total wall time.
+///
+/// `nodes[i].0` is the topology-relative path from the root (`[]` = root);
+/// each element is a child index into its parent's `children` vec.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BenchmarkReport {
+    pub total_time_secs: f64,
+    pub nodes: Vec<(Vec<usize>, NodeStats)>,
 }
 
 struct LiveTree {
@@ -217,7 +228,9 @@ fn build_tree_descs(
 fn build_aggregation(
     topology: &AggregationTopology,
     display_index: usize,
-    display: &mut LiveTree,
+    nodes: &mut Vec<(Vec<usize>, NodeStats)>,
+    live_tree: &mut LiveTree,
+    path: &mut Vec<usize>,
     pub_keys: &[XmssPublicKey],
     signatures: &[XmssSignature],
     overlap: usize,
@@ -234,15 +247,19 @@ fn build_aggregation(
     let mut child_display_index = display_index;
     for (child_idx, child) in topology.children.iter().enumerate() {
         let child_count = count_signers(child, overlap);
+        path.push(child_idx);
         let (child_pks, child_agg, _) = build_aggregation(
             child,
             child_display_index,
-            display,
+            nodes,
+            live_tree,
+            path,
             &pub_keys[child_start..child_start + child_count],
             &signatures[child_start..child_start + child_count],
             overlap,
             tracing,
         );
+        path.pop();
         child_pub_keys_list.push(child_pks);
         child_aggs.push(child_agg);
         child_display_index += count_nodes(child);
@@ -296,28 +313,34 @@ fn build_aggregation(
         );
     }
 
+    let own_display_index = display_index + count_nodes(topology) - 1;
+    let proof_kib = result.proof.proof_size_fe() * F::bits() / (8 * 1024);
+    let is_leaf = topology.children.is_empty();
+    let stats = NodeStats {
+        time_secs: elapsed.as_secs_f64(),
+        proof_kib,
+        cycles: result.metadata.as_ref().unwrap().cycles,
+        memory: result.metadata.as_ref().unwrap().memory,
+        poseidons: result.metadata.as_ref().unwrap().n_poseidons,
+        dots: result.metadata.as_ref().unwrap().n_extension_ops,
+        n_xmss: if is_leaf { Some(topology.raw_xmss) } else { None },
+    };
+    nodes.push((path.clone(), stats.clone()));
+    // LiveTree shares stdout with `tracing-forest`; only paint when tracing
+    // is off. (silent mode is handled inside `update_node`.)
     if !tracing {
-        let own_display_index = display_index + count_nodes(topology) - 1;
-        let proof_kib = result.proof.proof_size_fe() * F::bits() / (8 * 1024);
-        let is_leaf = topology.children.is_empty();
-        display.update_node(
-            own_display_index,
-            NodeStats {
-                time_secs: elapsed.as_secs_f64(),
-                proof_kib,
-                cycles: result.metadata.as_ref().unwrap().cycles,
-                memory: result.metadata.as_ref().unwrap().memory,
-                poseidons: result.metadata.as_ref().unwrap().n_poseidons,
-                dots: result.metadata.as_ref().unwrap().n_extension_ops,
-                n_xmss: if is_leaf { Some(topology.raw_xmss) } else { None },
-            },
-        );
+        live_tree.update_node(own_display_index, stats);
     }
 
     (global_pub_keys, result, elapsed.as_secs_f64())
 }
 
-pub fn run_aggregation_benchmark(topology: &AggregationTopology, overlap: usize, tracing: bool, silent: bool) -> f64 {
+pub fn run_aggregation_benchmark(
+    topology: &AggregationTopology,
+    overlap: usize,
+    tracing: bool,
+    silent: bool,
+) -> BenchmarkReport {
     // Tell macOS this is a user-initiated, latency-critical computation and
     // should not be throttled / App-Napped.
     #[cfg(target_os = "macos")]
@@ -353,8 +376,19 @@ pub fn run_aggregation_benchmark(topology: &AggregationTopology, overlap: usize,
         display.print_initial();
     }
 
-    let (global_pub_keys, aggregated_sigs, time) =
-        build_aggregation(topology, 0, &mut display, &pub_keys, &signatures, overlap, tracing);
+    let mut nodes: Vec<(Vec<usize>, NodeStats)> = Vec::new();
+    let mut path: Vec<usize> = Vec::new();
+    let (global_pub_keys, aggregated_sigs, total_time_secs) = build_aggregation(
+        topology,
+        0,
+        &mut nodes,
+        &mut display,
+        &mut path,
+        &pub_keys,
+        &signatures,
+        overlap,
+        tracing,
+    );
 
     // Verify root proof
     crate::xmss_verify_aggregation(
@@ -364,7 +398,8 @@ pub fn run_aggregation_benchmark(topology: &AggregationTopology, overlap: usize,
         BENCHMARK_SLOT,
     )
     .unwrap();
-    time
+
+    BenchmarkReport { total_time_secs, nodes }
 }
 
 // TODO is there a better fix?
@@ -420,7 +455,7 @@ fn test_aggregation_throughput_per_num_xmss() {
             children: vec![],
             log_inv_rate,
         };
-        let time = run_aggregation_benchmark(&topology, 0, false, true);
+        let time = run_aggregation_benchmark(&topology, 0, false, true).total_time_secs;
         num_xmss_and_time.push((num_xmss, time));
         println!(
             "{} XMSS -> {} XMSS/s",

--- a/crates/rec_aggregation/src/benchmark.rs
+++ b/crates/rec_aggregation/src/benchmark.rs
@@ -330,7 +330,10 @@ fn build_aggregation(
         let own_display_index = display_index + count_nodes(topology) - 1;
         live_tree.update_node(own_display_index, &stats);
     }
-    nodes.push(NodeReport { path: path.clone(), stats });
+    nodes.push(NodeReport {
+        path: path.clone(),
+        stats,
+    });
 
     (global_pub_keys, result, elapsed.as_secs_f64())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,9 +41,9 @@ fn run_with_warmup(topology: &AggregationTopology, overlap: usize, tracing: bool
     println!("warming up...");
     let _ = run_aggregation_benchmark(&warmup, 0, false, true);
     for i in 0..repeat {
-        let t = run_aggregation_benchmark(topology, overlap, tracing, false);
+        let report = run_aggregation_benchmark(topology, overlap, tracing, false);
         if repeat > 1 {
-            eprintln!("proof {}/{repeat}: {t:.3}s", i + 1);
+            eprintln!("proof {}/{repeat}: {:.3}s", i + 1, report.total_time_secs);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ fn run_with_warmup(topology: &AggregationTopology, overlap: usize, tracing: bool
     for i in 0..repeat {
         let report = run_aggregation_benchmark(topology, overlap, tracing, false);
         if repeat > 1 {
-            eprintln!("proof {}/{repeat}: {:.3}s", i + 1, report.total_time_secs);
+            eprintln!("proof {}/{repeat}: {:.3}s", i + 1, report.total_time_secs());
         }
     }
 }


### PR DESCRIPTION
 ## Overview

I'm trying to simulate and benchmark different aggregation topologies but `run_aggregation_benchmark` currently returns only total wall-time as f64. There are per-node metrics but they are locked inside the ANSI LiveTree rendering. 

So this PR exposes a structured, machine-readable view of the same data so external bench tooling can consume per-node cycles / memory / poseidons / extension-ops / proof_kib without parsing terminal output. The CLI behavior and on-screen output are unchanged.

##  Changes

- `run_aggregation_benchmark(topology, overlap, tracing, silent)` now returns `BenchmarkReport { total_time_secs, nodes: Vec<(path, NodeStats)> }` instead of just `f64 time`.
- `NodeStats` is now pub and with serde derives. BenchmarkReport is also Serialize / Deserialize so consumers can persist it directly (e.g. JSON).
- `build_aggregation` collects per-node stats into a `Vec` and renders into a separate `&mut LiveTree`, decoupling metrics collection from ANSI rendering — metrics populate regardless of tracing / silent, the tree only paints when stdout is free.
- `src/main.rs::run_with_warmup` updated to read `report.total_time_secs`