### PR TITLE
fix: added asserts for total_num_variables >= point.len() check.

### DIFF
--- a/crates/whir/src/lib.rs
+++ b/crates/whir/src/lib.rs
@@ -38,6 +38,12 @@ pub struct SparseStatement<EF> {
 
 impl<EF> SparseStatement<EF> {
     pub fn new(total_num_variables: usize, point: MultilinearPoint<EF>, values: Vec<SparseValue<EF>>) -> Self {
+        assert!(
+            total_num_variables >= point.len(),
+            "total_num_variables ({}) must be >= point.len() ({})",
+            total_num_variables,
+            point.len()
+        );
         Self {
             total_num_variables,
             point,
@@ -47,6 +53,12 @@ impl<EF> SparseStatement<EF> {
     }
 
     pub fn new_next(total_num_variables: usize, point: MultilinearPoint<EF>, values: Vec<SparseValue<EF>>) -> Self {
+        assert!(
+            total_num_variables >= point.len(),
+            "total_num_variables ({}) must be >= point.len() ({})",
+            total_num_variables,
+            point.len()
+        );
         Self {
             total_num_variables,
             point,
@@ -74,7 +86,9 @@ impl<EF> SparseStatement<EF> {
     }
 
     pub fn selector_num_variables(&self) -> usize {
-        self.total_num_variables - self.inner_num_variables()
+        self.total_num_variables
+            .checked_sub(self.inner_num_variables())
+            .expect("invariant violated: total_num_variables < point.len()")
     }
 
     pub fn inner_num_variables(&self) -> usize {


### PR DESCRIPTION
## Summary

Fixes a potential integer underflow bug in `SparseStatement::selector_num_variables()` where unchecked `usize` subtraction could silently wrap to a huge value in release builds, or panic in debug builds.

## Fix

Two targeted changes in `crates/whir/src/lib.rs`:

**1. Assert the invariant at construction time** in `new()` and `new_next()`:

```rust
assert!(
    total_num_variables >= point.len(),
    "total_num_variables ({}) must be >= point.len() ({})",
    total_num_variables,
    point.len()
);
```

**2. Use `checked_sub` in `selector_num_variables()`** as defense-in-depth:

```rust
pub fn selector_num_variables(&self) -> usize {
    self.total_num_variables
        .checked_sub(self.inner_num_variables())
        .expect("invariant violated: total_num_variables < point.len()")
}
```

Note: `unique_value()` and `dense()` are inherently safe because `unique_value` always uses an empty point (`len = 0`), and `dense` sets `total_num_variables = point.len()` exactly, therfore no assertion is needed there.

## Changes

- `crates/whir/src/lib.rs`: Add `assert!` in `SparseStatement::new()` and `SparseStatement::new_next()`, use `checked_sub` in `selector_num_variables()`

## Testing

All `cargo run` commands meantioned in the `README` are running properly.

## References

Fixes #182