### PR TITLE
fix: use rust-embed for DSL files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +367,19 @@ dependencies = [
  "rand_core",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -921,6 +944,7 @@ dependencies = [
  "objc2-foundation",
  "postcard",
  "rand",
+ "rust-embed",
  "serde",
  "sub_protocols",
  "tracing",
@@ -947,12 +971,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "globset",
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1260,6 +1328,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,6 +1404,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ tracing-subscriber = { version = "0.3.23", features = ["std", "env-filter"] }
 tracing-forest = { version = "0.3.0", features = ["ansi", "smallvec"] }
 postcard = { version = "1.1.3", features = ["alloc"] }
 lz4_flex = "0.13.0"
+rust-embed = { version = "8.7", features = ["debug-embed"] }
 
 [features]
 prox-gaps-conjecture = ["rec_aggregation/prox-gaps-conjecture"]

--- a/crates/rec_aggregation/Cargo.toml
+++ b/crates/rec_aggregation/Cargo.toml
@@ -25,6 +25,7 @@ postcard.workspace = true
 lz4_flex.workspace = true
 serde.workspace = true
 zk-alloc.workspace = true
+rust-embed = { workspace = true, features = ["debug-embed", "include-exclude"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = { version = "0.6.4", default-features = false, features = ["std"] }

--- a/crates/rec_aggregation/src/compilation.rs
+++ b/crates/rec_aggregation/src/compilation.rs
@@ -5,8 +5,9 @@ use lean_prover::{
     WHIR_SUBSEQUENT_FOLDING_FACTOR, default_whir_config,
 };
 use lean_vm::*;
+use rust_embed::Embed;
 use std::collections::{BTreeMap, HashMap};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use sub_protocols::{N_VARS_TO_SEND_GKR_COEFFS, min_stacked_n_vars, total_whir_statements};
 use tracing::instrument;
@@ -27,6 +28,26 @@ pub fn init_aggregation_bytecode() {
     BYTECODE.get_or_init(compile_main_program_self_referential);
 }
 
+#[derive(Embed)]
+#[folder = "."]
+#[include = "**/*.py"]
+#[exclude = "tests/*"]
+struct ZkDslFiles;
+
+fn zk_dsl_dir() -> &'static Path {
+    static DIR: OnceLock<PathBuf> = OnceLock::new();
+    DIR.get_or_init(|| {
+        let dir = std::env::temp_dir().join(concat!("rec_aggregation-", env!("CARGO_PKG_VERSION")));
+        std::fs::create_dir_all(&dir).expect("create rec_aggregation cache dir");
+        for name in ZkDslFiles::iter() {
+            let f = ZkDslFiles::get(&name).expect("embedded zkDSL file present");
+            std::fs::write(dir.join(name.as_ref()), &f.data).expect("write embedded zkDSL file");
+        }
+        dir
+    })
+    .as_path()
+}
+
 fn compile_main_program(program_log_size: usize, bytecode_zero_eval: F) -> Bytecode {
     let bytecode_point_n_vars = program_log_size + log2_ceil_usize(N_INSTRUCTION_COLUMNS);
     let claim_data_size = (bytecode_point_n_vars + 1) * DIMENSION;
@@ -39,11 +60,11 @@ fn compile_main_program(program_log_size: usize, bytecode_zero_eval: F) -> Bytec
     let input_data_size_padded = input_data_size.next_multiple_of(DIGEST_LEN);
     let replacements = build_replacements(program_log_size, bytecode_zero_eval, input_data_size_padded);
 
-    let filepath = Path::new(env!("CARGO_MANIFEST_DIR"))
+    let filepath = zk_dsl_dir()
         .join("main.py")
-        .to_str()
-        .unwrap()
-        .to_string();
+        .into_os_string()
+        .into_string()
+        .unwrap();
     compile_program_with_flags(&ProgramSource::Filepath(filepath), CompilationFlags { replacements })
 }
 


### PR DESCRIPTION
## Problem

`env!` is evaluated at build time, so for example if we compile the crate into static libraries, the path to the DSL files will be hardcoded into the binary. This will be something like `/user/tom/leanMultiSig/main.py`. This is usually okay for local development, however when we want to package this so that we can use it in Python, the path will be fetched at runtime.

## Potential solutions

There are two solutions that I know of for solving this:

- explicitly pass the path to main.py in as a parameter when compiling main
- ensure that even after compiling, we have a valid path to the main.py file

This PR goes with the second option, by embedding the dsl files into the binary with `rust-embed` and then creating a path to them at runtime when needed. This means that users of this library will not need to worry about supplying a path to the main.py file.