### PR TITLE
fix(poly): handle packed MLEs in MleOwned::as_constant

### DIFF
--- a/crates/backend/poly/src/mle/mle_single_owned.rs
+++ b/crates/backend/poly/src/mle/mle_single_owned.rs
@@ -154,6 +154,13 @@ impl<EF: ExtensionField<PF<EF>>> MleOwned<EF> {
     }
 
     pub fn as_constant(&self) -> EF {
+        // When the MLE is still in packed form, unpack first then recurse.
+        // The end of sumcheck folding can leave a polynomial in
+        // BasePacked / ExtensionPacked state even after it has been reduced
+        // to a single value, which would otherwise hit `unreachable!()` below.
+        if self.is_packed() {
+            return self.unpack().by_ref().clone_to_owned().as_constant();
+        }
         assert_eq!(self.n_vars(), 0);
         match self {
             Self::Base(v) => EF::from(v[0]),


### PR DESCRIPTION
Sumcheck folding can leave the polynomial in BasePacked / ExtensionPacked state after it has been reduced to a single value, which then hits `unreachable!()` in `as_constant`. Unpack first then recurse so the match arms for the unpacked variants handle it.

On linux systems the bindings were hitting the unreachable code path, this is a fix generated using AI.