### PR TITLE
Faster update twiddles function in whir crate

### DIFF
--- a/crates/whir/src/dft.rs
+++ b/crates/whir/src/dft.rs
@@ -88,9 +88,12 @@ impl<F: TwoAdicField> EvalsDft<F> {
             nth_root.extend(generator.shifted_powers(base).take(nb_steps));
         }
 
-        *guard = (0..lg_n)
-            .map(|i| nth_root.iter().step_by(1 << i).copied().collect())
-            .collect();
+        let old_twiddles = std::mem::take(&mut *guard);
+        let mut twiddles = Vec::with_capacity(diff_log + old_twiddles.len());
+        twiddles.extend((0..diff_log).map(|i| nth_root.iter().step_by(1 << i).copied().collect::<Vec<_>>()));
+        twiddles.extend(old_twiddles);
+
+        *guard = twiddles;
     }
 }
 
@@ -406,8 +409,8 @@ fn fft_double_layer_single_twiddle<F: Field, Fly: Butterfly<F>>(
     block: &mut DoubleLayerBlockDecomposition<'_, F>,
     butterfly: Fly,
 ) {
-    butterfly.apply_to_rows(block.0.0, block.0.1);
-    butterfly.apply_to_rows(block.1.0, block.1.1);
+    butterfly.apply_to_rows(block.0 .0, block.0 .1);
+    butterfly.apply_to_rows(block.1 .0, block.1 .1);
 }
 
 #[inline]
@@ -416,8 +419,8 @@ fn fft_double_layer_double_twiddle<F: Field, Fly0: Butterfly<F>, Fly1: Butterfly
     fly0: Fly0,
     fly1: Fly1,
 ) {
-    fly0.apply_to_rows(block.0.0, block.1.0);
-    fly1.apply_to_rows(block.0.1, block.1.1);
+    fly0.apply_to_rows(block.0 .0, block.1 .0);
+    fly1.apply_to_rows(block.0 .1, block.1 .1);
 }
 
 /// A type representing a decomposition of an FFT block into eight sub-blocks.
@@ -432,10 +435,10 @@ fn fft_triple_layer_single_twiddle<F: Field, Fly: Butterfly<F>>(
     block: &mut TripleLayerBlockDecomposition<'_, F>,
     butterfly: Fly,
 ) {
-    butterfly.apply_to_rows(block.0.0.0, block.0.0.1);
-    butterfly.apply_to_rows(block.0.1.0, block.0.1.1);
-    butterfly.apply_to_rows(block.1.0.0, block.1.0.1);
-    butterfly.apply_to_rows(block.1.1.0, block.1.1.1);
+    butterfly.apply_to_rows(block.0 .0 .0, block.0 .0 .1);
+    butterfly.apply_to_rows(block.0 .1 .0, block.0 .1 .1);
+    butterfly.apply_to_rows(block.1 .0 .0, block.1 .0 .1);
+    butterfly.apply_to_rows(block.1 .1 .0, block.1 .1 .1);
 }
 
 #[inline]
@@ -444,10 +447,10 @@ fn fft_triple_layer_double_twiddle<F: Field, Fly0: Butterfly<F>, Fly1: Butterfly
     fly0: Fly0,
     fly1: Fly1,
 ) {
-    fly0.apply_to_rows(block.0.0.0, block.0.1.0);
-    fly1.apply_to_rows(block.0.0.1, block.0.1.1);
-    fly0.apply_to_rows(block.1.0.0, block.1.1.0);
-    fly1.apply_to_rows(block.1.0.1, block.1.1.1);
+    fly0.apply_to_rows(block.0 .0 .0, block.0 .1 .0);
+    fly1.apply_to_rows(block.0 .0 .1, block.0 .1 .1);
+    fly0.apply_to_rows(block.1 .0 .0, block.1 .1 .0);
+    fly1.apply_to_rows(block.1 .0 .1, block.1 .1 .1);
 }
 
 #[inline]
@@ -458,10 +461,10 @@ fn fft_triple_layer_quad_twiddle<F: Field, Fly: Butterfly<F>>(
     fly2: Fly,
     fly3: Fly,
 ) {
-    fly0.apply_to_rows(block.0.0.0, block.1.0.0);
-    fly1.apply_to_rows(block.0.0.1, block.1.0.1);
-    fly2.apply_to_rows(block.0.1.0, block.1.1.0);
-    fly3.apply_to_rows(block.0.1.1, block.1.1.1);
+    fly0.apply_to_rows(block.0 .0 .0, block.1 .0 .0);
+    fly1.apply_to_rows(block.0 .0 .1, block.1 .0 .1);
+    fly2.apply_to_rows(block.0 .1 .0, block.1 .1 .0);
+    fly3.apply_to_rows(block.0 .1 .1, block.1 .1 .1);
 }
 
 /// Estimates the optimal workload size for `T` to fit in L1 cache.
@@ -594,7 +597,7 @@ mod tests {
     use field::{PrimeCharacteristicRing, TwoAdicField};
     use koala_bear::{KoalaBear, QuinticExtensionFieldKB};
     use poly::*;
-    use rand::{RngExt, SeedableRng, rngs::StdRng};
+    use rand::{rngs::StdRng, RngExt, SeedableRng};
 
     use crate::*;
 

--- a/crates/whir/src/dft.rs
+++ b/crates/whir/src/dft.rs
@@ -62,13 +62,35 @@ impl<F: TwoAdicField> EvalsDft<F> {
     }
 
     pub(crate) fn update_twiddles(&self, fft_len: usize) {
-        // TODO: This recomputes the entire table from scratch if we
-        // need it to be larger, which is wasteful.
         let mut guard = self.twiddles.write().unwrap();
-        let curr_max_fft_len = 1 << guard.len();
-        if fft_len > curr_max_fft_len {
-            *guard = self.roots_of_unity_table(fft_len);
+
+        let lg_n = log2_strict_usize(fft_len);
+
+        //if the current size is already big enough we don't do anything
+        if lg_n <= guard.len() {
+            return;
         }
+
+        //if current twiddles is empty we compute from nothing
+        if guard.is_empty() {
+            *guard = self.roots_of_unity_table(fft_len);
+            return;
+        }
+
+        let diff_log = lg_n - guard.len();
+        let nb_steps = 1 << diff_log; //number of missing points between each preexisting points
+
+        let generator = F::two_adic_generator(lg_n);
+
+        let table = guard[0].clone();
+        let mut nth_root = Vec::with_capacity(table.len() * nb_steps);
+        for &base in &table {
+            nth_root.extend(generator.shifted_powers(base).take(nb_steps));
+        }
+
+        *guard = (0..lg_n)
+            .map(|i| nth_root.iter().step_by(1 << i).copied().collect())
+            .collect();
     }
 }
 

--- a/crates/whir/src/dft.rs
+++ b/crates/whir/src/dft.rs
@@ -409,8 +409,8 @@ fn fft_double_layer_single_twiddle<F: Field, Fly: Butterfly<F>>(
     block: &mut DoubleLayerBlockDecomposition<'_, F>,
     butterfly: Fly,
 ) {
-    butterfly.apply_to_rows(block.0 .0, block.0 .1);
-    butterfly.apply_to_rows(block.1 .0, block.1 .1);
+    butterfly.apply_to_rows(block.0.0, block.0.1);
+    butterfly.apply_to_rows(block.1.0, block.1.1);
 }
 
 #[inline]
@@ -419,8 +419,8 @@ fn fft_double_layer_double_twiddle<F: Field, Fly0: Butterfly<F>, Fly1: Butterfly
     fly0: Fly0,
     fly1: Fly1,
 ) {
-    fly0.apply_to_rows(block.0 .0, block.1 .0);
-    fly1.apply_to_rows(block.0 .1, block.1 .1);
+    fly0.apply_to_rows(block.0.0, block.1.0);
+    fly1.apply_to_rows(block.0.1, block.1.1);
 }
 
 /// A type representing a decomposition of an FFT block into eight sub-blocks.
@@ -435,10 +435,10 @@ fn fft_triple_layer_single_twiddle<F: Field, Fly: Butterfly<F>>(
     block: &mut TripleLayerBlockDecomposition<'_, F>,
     butterfly: Fly,
 ) {
-    butterfly.apply_to_rows(block.0 .0 .0, block.0 .0 .1);
-    butterfly.apply_to_rows(block.0 .1 .0, block.0 .1 .1);
-    butterfly.apply_to_rows(block.1 .0 .0, block.1 .0 .1);
-    butterfly.apply_to_rows(block.1 .1 .0, block.1 .1 .1);
+    butterfly.apply_to_rows(block.0.0.0, block.0.0.1);
+    butterfly.apply_to_rows(block.0.1.0, block.0.1.1);
+    butterfly.apply_to_rows(block.1.0.0, block.1.0.1);
+    butterfly.apply_to_rows(block.1.1.0, block.1.1.1);
 }
 
 #[inline]
@@ -447,10 +447,10 @@ fn fft_triple_layer_double_twiddle<F: Field, Fly0: Butterfly<F>, Fly1: Butterfly
     fly0: Fly0,
     fly1: Fly1,
 ) {
-    fly0.apply_to_rows(block.0 .0 .0, block.0 .1 .0);
-    fly1.apply_to_rows(block.0 .0 .1, block.0 .1 .1);
-    fly0.apply_to_rows(block.1 .0 .0, block.1 .1 .0);
-    fly1.apply_to_rows(block.1 .0 .1, block.1 .1 .1);
+    fly0.apply_to_rows(block.0.0.0, block.0.1.0);
+    fly1.apply_to_rows(block.0.0.1, block.0.1.1);
+    fly0.apply_to_rows(block.1.0.0, block.1.1.0);
+    fly1.apply_to_rows(block.1.0.1, block.1.1.1);
 }
 
 #[inline]
@@ -461,10 +461,10 @@ fn fft_triple_layer_quad_twiddle<F: Field, Fly: Butterfly<F>>(
     fly2: Fly,
     fly3: Fly,
 ) {
-    fly0.apply_to_rows(block.0 .0 .0, block.1 .0 .0);
-    fly1.apply_to_rows(block.0 .0 .1, block.1 .0 .1);
-    fly2.apply_to_rows(block.0 .1 .0, block.1 .1 .0);
-    fly3.apply_to_rows(block.0 .1 .1, block.1 .1 .1);
+    fly0.apply_to_rows(block.0.0.0, block.1.0.0);
+    fly1.apply_to_rows(block.0.0.1, block.1.0.1);
+    fly2.apply_to_rows(block.0.1.0, block.1.1.0);
+    fly3.apply_to_rows(block.0.1.1, block.1.1.1);
 }
 
 /// Estimates the optimal workload size for `T` to fit in L1 cache.
@@ -597,7 +597,7 @@ mod tests {
     use field::{PrimeCharacteristicRing, TwoAdicField};
     use koala_bear::{KoalaBear, QuinticExtensionFieldKB};
     use poly::*;
-    use rand::{rngs::StdRng, RngExt, SeedableRng};
+    use rand::{RngExt, SeedableRng, rngs::StdRng};
 
     use crate::*;
 


### PR DESCRIPTION
Did the TODO in dft.rs of the whir crate.
instead of recomputing everything we reuse the existing twiddles.
Here are benchmarks run in release mode comparing the new function to the old one.
The speedup is significant but drops down with the ratio of new to old twiddles size


```
start        target       update_twiddles     update_new    speedup
2^8          2^9                 1.816µs          537ns      3.38x (2x growth)
2^8          2^10                3.062µs        1.414µs      2.17x (4x growth)
2^8          2^11                7.926µs        3.295µs      2.41x (8x growth)
2^8          2^12               14.193µs        7.358µs      1.93x (16x growth)
2^12         2^13               25.152µs        7.051µs      3.57x (2x growth)
2^12         2^14               46.344µs       15.242µs      3.04x (4x growth)
2^12         2^15               86.562µs       35.265µs      2.45x (8x growth)
2^12         2^16              162.497µs       90.329µs      1.80x (16x growth)
2^16         2^17              328.373µs        97.45µs      3.37x (2x growth)
2^16         2^18              653.316µs      218.411µs      2.99x (4x growth)
2^16         2^19             1.298278ms      544.642µs      2.38x (8x growth)
2^16         2^20             2.603312ms     1.416323ms      1.84x (16x growth)
```