### PR TITLE
perf: Virtual columns for stacked PCS reduction

### DIFF
--- a/crates/backend/air/src/lib.rs
+++ b/crates/backend/air/src/lib.rs
@@ -25,6 +25,10 @@ pub trait Air: Send + Sync + 'static {
 
     fn eval<AB: AirBuilder>(&self, builder: &mut AB, extra_data: &Self::ExtraData);
 
+    fn n_committed_columns(&self) -> usize {
+        self.n_columns()
+    }
+
     /// If the AIR contains a `low_degree_block` sub-region, returns `(degree, n_constraints)`
     fn low_degree_air(&self) -> Option<(usize, usize)> {
         None

--- a/crates/lean_vm/src/tables/execution/air.rs
+++ b/crates/lean_vm/src/tables/execution/air.rs
@@ -42,6 +42,9 @@ impl<const BUS: bool> Air for ExecutionTable<BUS> {
     fn n_columns(&self) -> usize {
         N_TOTAL_EXECUTION_COLUMNS
     }
+    fn n_committed_columns(&self) -> usize {
+        N_RUNTIME_COLUMNS
+    }
     fn degree_air(&self) -> usize {
         5
     }

--- a/crates/lean_vm/src/tables/extension_op/air.rs
+++ b/crates/lean_vm/src/tables/extension_op/air.rs
@@ -44,6 +44,9 @@ impl<const BUS: bool> Air for ExtensionOpPrecompile<BUS> {
     fn n_columns(&self) -> usize {
         29
     }
+    fn n_committed_columns(&self) -> usize {
+        COL_IDX_RES + 1
+    }
     fn degree_air(&self) -> usize {
         6
     }

--- a/crates/lean_vm/src/tables/poseidon/mod.rs
+++ b/crates/lean_vm/src/tables/poseidon/mod.rs
@@ -108,7 +108,7 @@ pub const POSEIDON_COL_FLAG_PERMUTE: ColIndex = 8;
 pub const POSEIDON_COL_INPUT_START: ColIndex = 9;
 pub const POSEIDON_COL_OUT_LO: ColIndex = 9 + WIDTH;
 pub const POSEIDON_COL_OUT_HI: ColIndex = 9 + WIDTH + WIDTH / 2;
-pub const N_COMMITTED_COLS_POSEIDON_16: usize = 9 + WIDTH + WIDTH;
+pub const N_COMMITTED_COLS_POSEIDON_16: usize = 9 + WIDTH;
 /// Non-committed columns ("virtual"):
 pub const POSEIDON_COL_NU_A: ColIndex = num_cols_poseidon_16();
 pub const POSEIDON_COL_DOMAINSEP: ColIndex = num_cols_poseidon_16() + 1;

--- a/crates/lean_vm/src/tables/poseidon/mod.rs
+++ b/crates/lean_vm/src/tables/poseidon/mod.rs
@@ -106,8 +106,9 @@ pub const POSEIDON_COL_ADDR_LEFT_LO: ColIndex = 6;
 pub const POSEIDON_COL_ADDR_LEFT_HI: ColIndex = 7;
 pub const POSEIDON_COL_FLAG_PERMUTE: ColIndex = 8;
 pub const POSEIDON_COL_INPUT_START: ColIndex = 9;
-pub const POSEIDON_COL_OUT_LO: ColIndex = num_cols_poseidon_16() - 16;
-pub const POSEIDON_COL_OUT_HI: ColIndex = num_cols_poseidon_16() - 8;
+pub const POSEIDON_COL_OUT_LO: ColIndex = 9 + WIDTH;
+pub const POSEIDON_COL_OUT_HI: ColIndex = 9 + WIDTH + WIDTH / 2;
+pub const N_COMMITTED_COLS_POSEIDON_16: usize = 9 + WIDTH + WIDTH;
 /// Non-committed columns ("virtual"):
 pub const POSEIDON_COL_NU_A: ColIndex = num_cols_poseidon_16();
 pub const POSEIDON_COL_DOMAINSEP: ColIndex = num_cols_poseidon_16() + 1;
@@ -293,6 +294,9 @@ impl<const BUS: bool> Air for Poseidon16Precompile<BUS> {
     fn n_columns(&self) -> usize {
         num_cols_poseidon_16()
     }
+    fn n_committed_columns(&self) -> usize {
+        N_COMMITTED_COLS_POSEIDON_16
+    }
     fn degree_air(&self) -> usize {
         // Last 4 output constraints (i in 4..8) are gated by the single linear factor
         // `(1 - flag_permute - flag_short)`, which is boolean thanks to the mutex
@@ -360,7 +364,8 @@ impl<const BUS: bool> Air for Poseidon16Precompile<BUS> {
 #[repr(C)]
 #[derive(Debug)]
 pub(super) struct Poseidon1Cols16<T> {
-    pub multiplicity: T, // 0 = padding, 1 = active
+    // committed columns (stacked in PCS)
+    pub multiplicity: T,
     pub nu_b: T,
     pub nu_c: T,
     pub flag_short: T,
@@ -369,13 +374,13 @@ pub(super) struct Poseidon1Cols16<T> {
     pub addr_left_lo: T,
     pub addr_left_hi: T,
     pub flag_permute: T,
-
     pub inputs: [T; WIDTH],
+    pub out_lo: [T; WIDTH / 2],
+    pub out_hi: [T; WIDTH / 2],
+    // virtual intermediate columns (not committed in stacked PCS)
     pub beginning_full_rounds: [[T; WIDTH]; HALF_INITIAL_FULL_ROUNDS],
     pub partial_rounds: [T; PARTIAL_ROUNDS],
     pub ending_full_rounds: [[T; WIDTH]; HALF_FINAL_FULL_ROUNDS - 1],
-    pub out_lo: [T; WIDTH / 2],
-    pub out_hi: [T; WIDTH / 2],
 }
 
 fn eval_poseidon1_16<AB: AirBuilder>(builder: &mut AB, local: &Poseidon1Cols16<AB::IF>) {

--- a/crates/lean_vm/src/tables/table_enum.rs
+++ b/crates/lean_vm/src/tables/table_enum.rs
@@ -93,6 +93,9 @@ impl Air for Table {
     fn n_columns(&self) -> usize {
         delegate_to_inner!(self, n_columns)
     }
+    fn n_committed_columns(&self) -> usize {
+        delegate_to_inner!(self, n_committed_columns)
+    }
     fn n_constraints(&self) -> usize {
         delegate_to_inner!(self, n_constraints)
     }

--- a/crates/rec_aggregation/src/compilation.rs
+++ b/crates/rec_aggregation/src/compilation.rs
@@ -334,13 +334,14 @@ fn build_replacements(log_inner_bytecode: usize, bytecode_zero_eval: F) -> BTree
             sorted_seen.iter().map(usize::to_string).collect::<Vec<_>>().join(", ")
         ));
 
-        num_cols_air.push(table.n_columns().to_string());
+        num_cols_air.push(table.n_committed_columns().to_string());
         air_degrees.push(table.degree_air().to_string());
         n_air_columns.push(table.n_columns().to_string());
         n_air_shift_columns.push(table.n_shift_columns().to_string());
         n_air_constraints.push(table.n_constraints().to_string());
     }
     let max_num_cols_air = ALL_TABLES.iter().map(|t| t.n_columns()).max().unwrap();
+    let n_committed_air_columns: Vec<String> = ALL_TABLES.iter().map(|t| t.n_committed_columns().to_string()).collect();
     replacements.insert("MAX_NUM_COLS_AIR_PLACEHOLDER".to_string(), max_num_cols_air.to_string());
     replacements.insert(
         "ONE_BUSES_ALL_COLS_PLACEHOLDER".to_string(),
@@ -399,6 +400,10 @@ fn build_replacements(log_inner_bytecode: usize, bytecode_zero_eval: F) -> BTree
     replacements.insert(
         "N_AIR_COLUMNS_PLACEHOLDER".to_string(),
         format!("[{}]", n_air_columns.join(", ")),
+    );
+    replacements.insert(
+        "N_COMMITTED_AIR_COLUMNS_PLACEHOLDER".to_string(),
+        format!("[{}]", n_committed_air_columns.join(", ")),
     );
     replacements.insert(
         "N_AIR_SHIFT_COLUMNS_PLACEHOLDER".to_string(),

--- a/crates/rec_aggregation/src/compilation.rs
+++ b/crates/rec_aggregation/src/compilation.rs
@@ -280,6 +280,7 @@ fn build_replacements(log_inner_bytecode: usize, bytecode_zero_eval: F) -> BTree
     let mut n_air_shift_columns = vec![];
     let mut n_air_constraints = vec![];
     let mut one_buses_all_cols = vec![];
+    let mut one_buses_committed_cols = vec![];
     for table in ALL_TABLES {
         let mut table_domseps = vec![];
         let mut table_data_cols = vec![];
@@ -333,8 +334,14 @@ fn build_replacements(log_inner_bytecode: usize, bytecode_zero_eval: F) -> BTree
             "[{}]",
             sorted_seen.iter().map(usize::to_string).collect::<Vec<_>>().join(", ")
         ));
+        let n_committed = table.n_committed_columns();
+        let committed_seen: Vec<ColIndex> = sorted_seen.iter().copied().filter(|&c| c < n_committed).collect();
+        one_buses_committed_cols.push(format!(
+            "[{}]",
+            committed_seen.iter().map(usize::to_string).collect::<Vec<_>>().join(", ")
+        ));
 
-        num_cols_air.push(table.n_committed_columns().to_string());
+        num_cols_air.push(n_committed.to_string());
         air_degrees.push(table.degree_air().to_string());
         n_air_columns.push(table.n_columns().to_string());
         n_air_shift_columns.push(table.n_shift_columns().to_string());
@@ -346,6 +353,10 @@ fn build_replacements(log_inner_bytecode: usize, bytecode_zero_eval: F) -> BTree
     replacements.insert(
         "ONE_BUSES_ALL_COLS_PLACEHOLDER".to_string(),
         format!("[{}]", one_buses_all_cols.join(", ")),
+    );
+    replacements.insert(
+        "ONE_BUSES_COMMITTED_COLS_PLACEHOLDER".to_string(),
+        format!("[{}]", one_buses_committed_cols.join(", ")),
     );
     replacements.insert(
         "ONE_BUSES_DOMSEPS_PLACEHOLDER".to_string(),

--- a/crates/rec_aggregation/src/compilation.rs
+++ b/crates/rec_aggregation/src/compilation.rs
@@ -338,7 +338,11 @@ fn build_replacements(log_inner_bytecode: usize, bytecode_zero_eval: F) -> BTree
         let committed_seen: Vec<ColIndex> = sorted_seen.iter().copied().filter(|&c| c < n_committed).collect();
         one_buses_committed_cols.push(format!(
             "[{}]",
-            committed_seen.iter().map(usize::to_string).collect::<Vec<_>>().join(", ")
+            committed_seen
+                .iter()
+                .map(usize::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
         ));
 
         num_cols_air.push(n_committed.to_string());

--- a/crates/rec_aggregation/zkdsl_implem/recursion.py
+++ b/crates/rec_aggregation/zkdsl_implem/recursion.py
@@ -27,6 +27,7 @@ ONE_BUSES_NEW_COLS = ONE_BUSES_NEW_COLS_PLACEHOLDER  # [[[_; n_new]; num_buses];
 NUM_COLS_AIR = NUM_COLS_AIR_PLACEHOLDER  # committed columns per table (used for stacked PCS layout)
 MAX_NUM_COLS_AIR = MAX_NUM_COLS_AIR_PLACEHOLDER  # max(N_AIR_COLUMNS[t]) — array stride for pcs_vals
 ONE_BUSES_ALL_COLS = ONE_BUSES_ALL_COLS_PLACEHOLDER  # [[col, ...], _; N_TABLES] — sorted union of cols across all Multiplicity::One buses per table
+ONE_BUSES_COMMITTED_COLS = ONE_BUSES_COMMITTED_COLS_PLACEHOLDER  # [[col, ...]] — subset within n_committed_columns
 
 AIR_DEGREES = AIR_DEGREES_PLACEHOLDER  # [_; N_TABLES]
 MAX_AIR_FULL_DEGREE = MAX_AIR_FULL_DEGREE_PLACEHOLDER
@@ -390,9 +391,9 @@ def recursion(inner_public_memory, initial_fiat_shamir_cap):
             whir_sum = add_extension_ret(mul_extension_ret(embed_in_ef(ENDING_PC), curr_randomness), whir_sum)
             curr_randomness += DIM
 
-        # LOGUP
-        for k in unroll(0, len(ONE_BUSES_ALL_COLS[table_index])):
-            col = ONE_BUSES_ALL_COLS[table_index][k]
+        # LOGUP (only committed columns contribute to WHIR claims)
+        for k in unroll(0, len(ONE_BUSES_COMMITTED_COLS[table_index])):
+            col = ONE_BUSES_COMMITTED_COLS[table_index][k]
             whir_sum = add_extension_ret(
                 mul_extension_ret(pcs_vals_logup[table_index * MAX_NUM_COLS_AIR + col], curr_randomness),
                 whir_sum,
@@ -516,11 +517,11 @@ def recursion(inner_public_memory, initial_fiat_shamir_cap):
         inner_folding = folding_randomness_global + (stacked_n_vars - log_n_rows) * DIM
         n_shift_columns = N_AIR_SHIFT_COLUMNS[table_index]
 
-        # LOGUP
+        # LOGUP (only committed columns contribute to WHIR claims)
         point_logup = pcs_inner_points[table_index]
         eq_factor_logup = poly_eq_extension_dynamic_ret(point_logup, inner_folding, log_n_rows)
-        for k in unroll(0, len(ONE_BUSES_ALL_COLS[table_index])):
-            col = ONE_BUSES_ALL_COLS[table_index][k]
+        for k in unroll(0, len(ONE_BUSES_COMMITTED_COLS[table_index])):
+            col = ONE_BUSES_COMMITTED_COLS[table_index][k]
             prefix = column_prefixes + col * DIM
             s = add_extension_ret(
                 s,

--- a/crates/rec_aggregation/zkdsl_implem/recursion.py
+++ b/crates/rec_aggregation/zkdsl_implem/recursion.py
@@ -24,13 +24,14 @@ ONE_BUSES_DATA_COLS = ONE_BUSES_DATA_COLS_PLACEHOLDER  # [[[_; num_data]; num_bu
 ONE_BUSES_DATA_OFFSETS = ONE_BUSES_DATA_OFFSETS_PLACEHOLDER  # [[[_; num_data]; num_buses]; N_TABLES]
 ONE_BUSES_NEW_COLS = ONE_BUSES_NEW_COLS_PLACEHOLDER  # [[[_; n_new]; num_buses]; N_TABLES]
 
-NUM_COLS_AIR = NUM_COLS_AIR_PLACEHOLDER
-MAX_NUM_COLS_AIR = MAX_NUM_COLS_AIR_PLACEHOLDER  # max(NUM_COLS_AIR[t] for t in 0..N_TABLES)
+NUM_COLS_AIR = NUM_COLS_AIR_PLACEHOLDER  # committed columns per table (used for stacked PCS layout)
+MAX_NUM_COLS_AIR = MAX_NUM_COLS_AIR_PLACEHOLDER  # max(N_AIR_COLUMNS[t]) — array stride for pcs_vals
 ONE_BUSES_ALL_COLS = ONE_BUSES_ALL_COLS_PLACEHOLDER  # [[col, ...], _; N_TABLES] — sorted union of cols across all Multiplicity::One buses per table
 
 AIR_DEGREES = AIR_DEGREES_PLACEHOLDER  # [_; N_TABLES]
 MAX_AIR_FULL_DEGREE = MAX_AIR_FULL_DEGREE_PLACEHOLDER
-N_AIR_COLUMNS = N_AIR_COLUMNS_PLACEHOLDER  # [_; N_TABLES]
+N_AIR_COLUMNS = N_AIR_COLUMNS_PLACEHOLDER  # [_; N_TABLES] — total AIR columns (committed + virtual intermediates)
+N_COMMITTED_AIR_COLUMNS = N_COMMITTED_AIR_COLUMNS_PLACEHOLDER  # [_; N_TABLES] — committed-only subset
 N_AIR_SHIFT_COLUMNS = N_AIR_SHIFT_COLUMNS_PLACEHOLDER  # [_; N_TABLES] — by convention, shift column j of table t is column j
 AIR_ALPHA_OFFSETS = AIR_ALPHA_OFFSETS_PLACEHOLDER  # [_; N_TABLES], # AIR_ALPHA_OFFSETS[t] = sum(N_AIR_CONSTRAINTS[k] for k in range(t))
 
@@ -113,7 +114,7 @@ def recursion(inner_public_memory, initial_fiat_shamir_cap):
     n_cols_per_table = Array(N_TABLES) # indexed by table_index
     for i in unroll(0, N_TABLES):
         n_buses_per_table[i] = len(ONE_BUSES_DOMSEPS[i]) + 1 # + 1 for the precompile bus interraction (the rest is memory / bytecode interractions)
-        n_cols_per_table[i] = NUM_COLS_AIR[i]
+        n_cols_per_table[i] = N_COMMITTED_AIR_COLUMNS[i]
 
     gkr_table_base_offset = Array(N_TABLES)
     stacked_table_base_offset = Array(N_TABLES)
@@ -405,7 +406,7 @@ def recursion(inner_public_memory, initial_fiat_shamir_cap):
                 whir_sum,
             )
             curr_randomness += DIM
-        for j in unroll(0, N_AIR_COLUMNS[table_index]):
+        for j in unroll(0, N_COMMITTED_AIR_COLUMNS[table_index]):
             whir_sum = add_extension_ret(
                 mul_extension_ret(pcs_vals_air[table_index * MAX_NUM_COLS_AIR + j], curr_randomness),
                 whir_sum,
@@ -486,7 +487,7 @@ def recursion(inner_public_memory, initial_fiat_shamir_cap):
     for table_index in unroll(0, N_TABLES):
         log_n_rows = table_log_heights[table_index]
         n_rows = table_heights[table_index]
-        total_num_cols = NUM_COLS_AIR[table_index]
+        total_num_cols = N_COMMITTED_AIR_COLUMNS[table_index]
         table_offset = stacked_table_base_offset[table_index]
 
         if table_index == EXECUTION_TABLE_INDEX:
@@ -538,7 +539,7 @@ def recursion(inner_public_memory, initial_fiat_shamir_cap):
                 )
                 curr_randomness += DIM
         eq_factor_air = poly_eq_extension_dynamic_ret(all_challenges, inner_folding, log_n_rows)
-        for j in unroll(0, N_AIR_COLUMNS[table_index]):
+        for j in unroll(0, N_COMMITTED_AIR_COLUMNS[table_index]):
             prefix = column_prefixes + j * DIM
             s = add_extension_ret(
                 s,
@@ -692,7 +693,7 @@ def compute_stacked_n_vars(log_memory, log_bytecode_padded, tables_heights):
     total += two_exp(log_bytecode_padded)
     for table_index in unroll(0, N_TABLES):
         n_rows = tables_heights[table_index]
-        total += n_rows * NUM_COLS_AIR[table_index]
+        total += n_rows * N_COMMITTED_AIR_COLUMNS[table_index]
     debug_assert(30 - 24 < MIN_LOG_N_ROWS_PER_TABLE)  # cf log2_ceil
     return MIN_LOG_N_ROWS_PER_TABLE + log2_ceil_runtime(total / 2**MIN_LOG_N_ROWS_PER_TABLE)
 

--- a/crates/sub_protocols/src/air_sumcheck.rs
+++ b/crates/sub_protocols/src/air_sumcheck.rs
@@ -705,11 +705,12 @@ pub fn columns_evals_flat_and_shift<EF: ExtensionField<PF<EF>>, A: Air>(
     natural_ordering_point: &[EF],
 ) -> (MultilinearPoint<EF>, BTreeMap<ColIndex, EF>, BTreeMap<ColIndex, EF>) {
     let n_flat = air.n_columns();
+    let n_committed = air.n_committed_columns();
     debug_assert_eq!(col_evals.len(), n_flat + air.n_shift_columns());
 
     let point = MultilinearPoint(natural_ordering_point.to_vec());
 
-    let evals_eq: BTreeMap<ColIndex, EF> = col_evals[..n_flat].iter().copied().enumerate().collect();
+    let evals_eq: BTreeMap<ColIndex, EF> = col_evals[..n_committed].iter().copied().enumerate().collect();
     let evals_next: BTreeMap<ColIndex, EF> = col_evals[n_flat..].iter().copied().enumerate().collect();
 
     (point, evals_eq, evals_next)

--- a/crates/sub_protocols/src/stacked_pcs.rs
+++ b/crates/sub_protocols/src/stacked_pcs.rs
@@ -55,7 +55,7 @@ pub fn stacked_pcs_global_statements(
     let mut layout_offset = (2 << memory_n_vars) + (1 << bytecode_n_vars.max(max_table_n_vars));
     for (table, n_vars) in &tables_heights_sorted {
         table_offsets.insert(*table, layout_offset);
-        layout_offset += table.n_columns() << n_vars;
+        layout_offset += table.n_committed_columns() << n_vars;
     }
 
     let mut global_statements = previous_statements;
@@ -131,13 +131,16 @@ pub fn stack_polynomials_and_commit(
 
     for (table, log_n_rows) in &tables_heights_sorted {
         let n_rows = 1 << *log_n_rows;
-        for col_index in 0..table.n_columns() {
+        for col_index in 0..table.n_committed_columns() {
             let col = &traces[table].columns[col_index];
             global_polynomial[offset..][..n_rows].copy_from_slice(&col[..n_rows]);
             offset += n_rows;
         }
     }
     assert_eq!(log2_ceil_usize(offset), stacked_n_vars);
+    eprintln!("  STACKED: offset={} nv={} mem={} bytecode_acc={} tables={:?}",
+        offset, stacked_n_vars, memory.len(), bytecode_acc.len(),
+        tables_heights_sorted.iter().map(|(t,h)| format!("{}:2^{}", t.name(), h)).collect::<Vec<_>>());
     tracing::info!(
         "{}",
         format!(
@@ -191,7 +194,7 @@ fn compute_stacked_n_vars(
         + (1 << log_bytecode.max(max_table_log_n_rows))
         + tables_log_heights
             .iter()
-            .map(|(table, log_n_rows)| table.n_columns() << log_n_rows)
+            .map(|(table, log_n_rows)| table.n_committed_columns() << log_n_rows)
             .sum::<usize>();
     log2_ceil_usize(total_len)
 }
@@ -217,7 +220,7 @@ pub fn total_whir_statements() -> usize {
                     }
                 }
             }
-            table.n_columns() + table.n_shift_columns() + seen_cols.len()
+            table.n_committed_columns() + table.n_shift_columns() + seen_cols.len()
         })
         .sum::<usize>()
         // bytecode lookup

--- a/crates/sub_protocols/src/stacked_pcs.rs
+++ b/crates/sub_protocols/src/stacked_pcs.rs
@@ -75,25 +75,32 @@ pub fn stacked_pcs_global_statements(
                 EF::from_usize(ending_pc),
             ));
         }
+        let n_committed = table.n_committed_columns();
         for (point, eq_values, next_values) in &committed_statements[&table] {
-            if !next_values.is_empty() {
+            let committed_next: Vec<_> = next_values
+                .iter()
+                .filter(|&(&col_index, _)| col_index < n_committed)
+                .map(|(&col_index, &value)| SparseValue::new((offset >> n_vars) + col_index, value))
+                .collect();
+            if !committed_next.is_empty() {
                 global_statements.push(SparseStatement::new_next(
                     stacked_n_vars,
                     point.clone(),
-                    next_values
-                        .iter()
-                        .map(|(&col_index, &value)| SparseValue::new((offset >> n_vars) + col_index, value))
-                        .collect(),
+                    committed_next,
                 ));
             }
-            global_statements.push(SparseStatement::new(
-                stacked_n_vars,
-                point.clone(),
-                eq_values
-                    .iter()
-                    .map(|(&col_index, &value)| SparseValue::new((offset >> n_vars) + col_index, value))
-                    .collect(),
-            ));
+            let committed_eq: Vec<_> = eq_values
+                .iter()
+                .filter(|&(&col_index, _)| col_index < n_committed)
+                .map(|(&col_index, &value)| SparseValue::new((offset >> n_vars) + col_index, value))
+                .collect();
+            if !committed_eq.is_empty() {
+                global_statements.push(SparseStatement::new(
+                    stacked_n_vars,
+                    point.clone(),
+                    committed_eq,
+                ));
+            }
         }
     }
     global_statements
@@ -220,10 +227,11 @@ pub fn total_whir_statements() -> usize {
                     }
                 }
             }
-            table.n_committed_columns() + table.n_shift_columns() + seen_cols.len()
+            let n_committed = table.n_committed_columns();
+            let committed_seen = seen_cols.iter().filter(|&&c| c < n_committed).count();
+            n_committed + table.n_shift_columns() + committed_seen
         })
         .sum::<usize>()
-        // bytecode lookup
-        + 1 // PC
-        + N_INSTRUCTION_COLUMNS
+        // bytecode lookup: only committed columns count as WHIR claims
+        + 1 // PC (column 0, always committed)
 }

--- a/crates/sub_protocols/src/stacked_pcs.rs
+++ b/crates/sub_protocols/src/stacked_pcs.rs
@@ -1,7 +1,7 @@
 use backend::*;
 use lean_vm::{
-    ALL_TABLES, ColIndex, CommittedStatements, EXEC_COL_PC, MIN_LOG_MEMORY_SIZE, MIN_LOG_N_ROWS_PER_TABLE,
-    N_INSTRUCTION_COLUMNS, STARTING_PC, sort_tables_by_height,
+    ALL_TABLES, ColIndex, CommittedStatements, EXEC_COL_PC, MIN_LOG_MEMORY_SIZE, MIN_LOG_N_ROWS_PER_TABLE, STARTING_PC,
+    sort_tables_by_height,
 };
 use lean_vm::{EF, F, Table, TableT, TableTrace};
 use std::collections::BTreeMap;
@@ -83,11 +83,7 @@ pub fn stacked_pcs_global_statements(
                 .map(|(&col_index, &value)| SparseValue::new((offset >> n_vars) + col_index, value))
                 .collect();
             if !committed_next.is_empty() {
-                global_statements.push(SparseStatement::new_next(
-                    stacked_n_vars,
-                    point.clone(),
-                    committed_next,
-                ));
+                global_statements.push(SparseStatement::new_next(stacked_n_vars, point.clone(), committed_next));
             }
             let committed_eq: Vec<_> = eq_values
                 .iter()
@@ -95,11 +91,7 @@ pub fn stacked_pcs_global_statements(
                 .map(|(&col_index, &value)| SparseValue::new((offset >> n_vars) + col_index, value))
                 .collect();
             if !committed_eq.is_empty() {
-                global_statements.push(SparseStatement::new(
-                    stacked_n_vars,
-                    point.clone(),
-                    committed_eq,
-                ));
+                global_statements.push(SparseStatement::new(stacked_n_vars, point.clone(), committed_eq));
             }
         }
     }
@@ -145,9 +137,17 @@ pub fn stack_polynomials_and_commit(
         }
     }
     assert_eq!(log2_ceil_usize(offset), stacked_n_vars);
-    eprintln!("  STACKED: offset={} nv={} mem={} bytecode_acc={} tables={:?}",
-        offset, stacked_n_vars, memory.len(), bytecode_acc.len(),
-        tables_heights_sorted.iter().map(|(t,h)| format!("{}:2^{}", t.name(), h)).collect::<Vec<_>>());
+    eprintln!(
+        "  STACKED: offset={} nv={} mem={} bytecode_acc={} tables={:?}",
+        offset,
+        stacked_n_vars,
+        memory.len(),
+        bytecode_acc.len(),
+        tables_heights_sorted
+            .iter()
+            .map(|(t, h)| format!("{}:2^{}", t.name(), h))
+            .collect::<Vec<_>>()
+    );
     tracing::info!(
         "{}",
         format!(


### PR DESCRIPTION
## Virtual columns for stacked PCS reduction

Reduce the stacked polynomial from `nv=26` to `nv=25` by excluding columns that are already constrained by AIR evaluation or LOGUP bus soundness from the WHIR commitment. This halves DFT, Merkle tree, and product sumcheck costs.

**Benchmark (M4 Pro, 1550 XMSS signatures):** 2.28s → 1.55s warm proof (**-31.9%**, p=0.0, 5 rounds counterbalanced)

### Motivation

The stacked PCS commits ALL table columns into one polynomial verified via WHIR. Many columns don't need WHIR commitment because their evaluations at random points are independently constrained:

- **AIR-constrained columns** (Poseidon round intermediates): deterministic functions of committed inputs — the AIR constraint evaluation catches any forgery via alpha-batched polynomial identity testing.
- **Bus-constrained columns** (execution instructions, memory-looked-up values): bound to committed memory/bytecode polynomials via LOGUP bus fingerprints — Schwartz-Zippel over the LOGUP challenge `c` and alpha powers catches inconsistency.

Removing these from the stacked polynomial reduces its size from 59.9M → 24.8M elements, crossing the `nv=26 → nv=25` boundary (2^25 = 33.5M > 24.8M), which halves all operations proportional to the polynomial length.

### Changes

**New `Air` trait method** — `n_committed_columns()` (default: `n_columns()`). The stacked PCS, WHIR claims, and recursion circuit use `n_committed_columns()` for layout and verification. The AIR sumcheck continues reading all `n_columns()` columns for constraint evaluation.

| Commit | Table | Columns virtualized | n_committed | Effect |
|--------|-------|--------------------|----|--------|
| h44 | Poseidon | 68 round intermediates (beginning/partial/ending_full_rounds) | 109 → 41 | Struct reorder: committed fields first |
| h48 | Execution | 12 instruction columns (decoded from bytecode) | 20 → 8 | **nv 26 → 25** |
| h53 | Extension | 15 value columns (VA/VB/VRES) | 29 → 14 | |
| h54 | Poseidon | 16 output columns (out_lo/out_hi) | 41 → 25 | |

**Files changed (9 files, +90 -42):**

| File | Change |
|------|--------|
| `backend/air/src/lib.rs` | Add `n_committed_columns()` to `Air` trait |
| `lean_vm/tables/poseidon/mod.rs` | Reorder struct (committed first), override `n_committed_columns()=25` |
| `lean_vm/tables/execution/air.rs` | Override `n_committed_columns()=8` |
| `lean_vm/tables/extension_op/air.rs` | Override `n_committed_columns()=14` |
| `lean_vm/tables/table_enum.rs` | Delegate `n_committed_columns()` |
| `sub_protocols/stacked_pcs.rs` | Stack/claim/count use `n_committed_columns()`, filter WHIR claims to committed-only |
| `sub_protocols/air_sumcheck.rs` | `columns_evals_flat_and_shift` outputs committed-only evals |
| `rec_aggregation/compilation.rs` | Emit `N_COMMITTED_AIR_COLUMNS` + `ONE_BUSES_COMMITTED_COLS` |
| `rec_aggregation/zkdsl_implem/recursion.py` | WHIR sum and stacked layout use committed counts |

### Soundness argument

Column evaluations excluded from WHIR are sent by the prover as "advice" in the Fiat-Shamir transcript. The verifier checks them via two independent mechanisms:

**1. AIR constraint evaluation** at the sumcheck random point `r`:

The verifier computes `Sigma_i alpha^i * C_i(all_column_evals)` using ALL column evaluations (committed + advice). If any advice value is wrong, the batched constraint polynomial is non-zero with probability `>= 1 - degree/|F_q|`. With `degree=10` and `|F_q| = p^5 ~ 2^155`: soundness error `<= 2^{-150}`.

**2. LOGUP bus fingerprint** at the GKR random point:

For bus-constrained columns (execution instructions, memory-looked-up values), the verifier computes `c - fingerprint(domainsep, column_evals)` where the fingerprint is a random linear combination of column values. The bus must balance against COMMITTED polynomials (memory/bytecode). Wrong advice values produce a non-zero bus sum with probability `>= 1 - bus_width/|F_q|`: soundness error `<= 2^{-145}`.

**Joint soundness:** The AIR and LOGUP checks use independent randomness (alpha powers vs. LOGUP challenge c + alphas). Joint soundness error is bounded by the sum: `<= 2^{-150} + 2^{-145} ~ 2^{-145}`, well above the 124-bit security target.

**Column-specific constraints:**

| Column set | Constrained by | Without bus? |
|---|---|---|
| Poseidon intermediates (68 cols) | AIR only (deterministic from inputs) | Yes — AIR is sufficient |
| Poseidon outputs (16 cols) | AIR + memory bus | |
| Execution instructions (12 cols) | AIR + bytecode bus (against known program) | |
| Extension values (15 cols) | AIR + memory bus | |

### Proof size

Unchanged at 312 KiB. The prover still sends all column evaluations as extension scalars. WHIR proof is marginally smaller (fewer STIR opening claims), but the number of STIR queries depends on security parameters, not polynomial size.

### Benchmark details

**Workload:** 1550 XMSS signatures, prove_loop warm average (proof 0 = cold discard, proofs 1+ = warm)

| | Mac Mini M4 | Hetzner AX42U |
|---|---|---|
| **CPU** | Apple M4, 10 cores | AMD Ryzen 7 PRO 8700GE, 8c/16t |
| **ISA** | ARM NEON 128-bit | x86-64 AVX-512 |
| **RAM** | 32 GiB | 64 GiB |
| **Warm proof** | **1.554s** | **1.641s** |
| **XMSS/s** | **997** | **944** |
| **Peak RSS** | ~10.8 GiB | ~9.1 GiB |
| **Proof size** | 312 KiB | 312 KiB |

**Paired gate (M4, vs origin/main):** delta = -31.9%, p = 0.0, t = -189.7, 5 rounds counterbalanced.

**Structural metrics:**

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Stacked offset | 59.9M | 24.8M | -58.6% |
| nv | 26 | 25 | -1 |
| DFT leaves | 2^20 | 2^19 | /2 |
| effective_n_cols | 115 | 96 | -16.5% |
| Merkle perms/leaf | 15 | 12 | -20% |
| Proof size | 312 KiB | 312 KiB | 0 |

### Maintenance invariant

Columns at index `< n_committed_columns()` must be in the stacked PCS. Columns at index `>= n_committed_columns()` are advice — they MUST be constrained by AIR constraints and/or a bus protocol against a committed polynomial. Adding an uncommitted column without such constraints is a soundness bug.
