### PR TITLE
Use copy_nonoverlapping in allocator realloc

### DIFF
--- a/crates/backend/zk-alloc/src/lib.rs
+++ b/crates/backend/zk-alloc/src/lib.rs
@@ -190,7 +190,7 @@ unsafe impl GlobalAlloc for ZkAllocator {
         let new_layout = unsafe { Layout::from_size_align_unchecked(new_size, layout.align()) };
         let new_ptr = unsafe { self.alloc(new_layout) };
         if !new_ptr.is_null() {
-            unsafe { std::ptr::copy(ptr, new_ptr, layout.size()) };
+            unsafe { std::ptr::copy_nonoverlapping(ptr, new_ptr, layout.size()) };
             unsafe { self.dealloc(ptr, layout) };
         }
         new_ptr


### PR DESCRIPTION
## Summary
Use `std::ptr::copy_nonoverlapping` in `zk-alloc`'s `realloc` path.

## Why
For a growth `realloc`, the old allocation and the new allocation should not overlap, so `copy_nonoverlapping` is the more precise primitive.

## Assembly note
`copy_nonoverlapping` lowers to `memcpy`, while `copy` lowers to `memmove`.

```asm
example::no_overlap::h1eef91d99543e88e:
  jmp qword ptr [rip + memcpy@GOTPCREL]

example::overlap_ok::hada851ac7e81e4a4:
  jmp qword ptr [rip + memmove@GOTPCREL]
```

non_overlapping

and overlapping:

```asm
example::realloc_style_copy::h30efdff70a615df7:
        mov     rax, rdi
        mov     rdi, rsi
        mov     rsi, rax
        jmp     qword ptr [rip + memmove@GOTPCREL]

example::realloc_style_copy_no_overlap::hcad6957ed56441d2:
        mov     rax, rdi
        mov     rdi, rsi
        mov     rsi, rax
        jmp     qword ptr [rip + memcpy@GOTPCREL]
```

## Validation
`cargo test -p zk-alloc`
