### PR TITLE
whir: avoid serial 256 MiB copy of combined-statement weights

### DIFF
--- a/crates/whir/src/open.rs
+++ b/crates/whir/src/open.rs
@@ -422,7 +422,7 @@ where
         let (weights, sum) = combine_statement::<EF>(statement, combination_randomness);
 
         let mut evals = evals.pack();
-        let mut weights = Mle::Owned(MleOwned::ExtensionPacked(ArenaVec::from_slice(&weights)));
+        let mut weights = Mle::Owned(MleOwned::ExtensionPacked(weights));
         let (challengess, new_sum, new_evals, new_weights) = run_product_sumcheck(
             &evals.by_ref(),
             &weights.by_ref(),
@@ -515,7 +515,7 @@ where
 }
 
 #[instrument(skip_all, fields(num_constraints = statements.len(), n_vars = statements[0].total_num_variables))]
-fn combine_statement<EF>(statements: &[SparseStatement<EF>], gamma: EF) -> (Vec<EFPacking<EF>>, EF)
+fn combine_statement<EF>(statements: &[SparseStatement<EF>], gamma: EF) -> (ArenaVec<EFPacking<EF>>, EF)
 where
     EF: ExtensionField<PF<EF>>,
 {
@@ -528,13 +528,13 @@ where
         !s.is_next && s.values.len() == 1 && s.values[0].selector == 0 && s.inner_num_variables() == num_variables
     };
 
-    let mut combined_weights: Vec<EFPacking<EF>>;
+    let mut combined_weights: ArenaVec<EFPacking<EF>>;
     let mut combined_sum = EF::ZERO;
     let mut gamma_pow = EF::ONE;
 
     let start_idx = match statements {
         [a, b, ..] if is_full(a) && is_full(b) => {
-            combined_weights = unsafe { uninitialized_vec(out_len) };
+            combined_weights = unsafe { ArenaVec::uninitialized(out_len) };
             let sa = gamma_pow;
             let sb = gamma_pow * gamma;
             combined_sum = a.values[0].value * sa + b.values[0].value * sb;
@@ -543,7 +543,7 @@ where
             2
         }
         [a, ..] if is_full(a) => {
-            combined_weights = unsafe { uninitialized_vec(out_len) };
+            combined_weights = unsafe { ArenaVec::uninitialized(out_len) };
             let sa = gamma_pow;
             combined_sum = a.values[0].value * sa;
             gamma_pow *= gamma;
@@ -551,7 +551,8 @@ where
             1
         }
         _ => {
-            combined_weights = EFPacking::<EF>::zero_vec(out_len);
+            // SAFETY: all-zero bytes are a valid `EFPacking` (Montgomery packing, ZERO = 0).
+            combined_weights = unsafe { ArenaVec::zeroed(out_len) };
             0
         }
     };


### PR DESCRIPTION
## Problem

The merge of main into devnet4 (8eec56c1) changed `MleOwned` to hold an `ArenaVec`, but `combine_statement` in `crates/whir/src/open.rs` still returned a glibc-heap `Vec<EFPacking<EF>>`, which was then bridged with `ArenaVec::from_slice(&weights)`. At n_vars=24 that is a **single-threaded memcpy of ~256 MiB per proof** while all worker threads sit idle, plus the same data traversing the memory hierarchy twice.

This was found while investigating a machine-specific perf regression: the copy is a fixed serial tax competing against the merge's parallel-kernel gains. On a Zen4 box the gains outweigh the tax; on a Zen5 box (Ryzen 9700X, smaller remaining gains) it showed up as a net −5.3% in XMSS aggregation throughput. `--tracing` pinpointed it: `run_initial_sumcheck_rounds` *self* time went from 0.01% to 7.94% (~25 ms) with identical children, and `perf` showed `ArenaVec::from_slice` only in the regressed binary.

## Fix

Build the weights directly in an `ArenaVec` so it is moved, never copied. All writers (`compute_eval_eq_packed*`, `split_at_mut_many`) take `&mut [T]` and work unchanged via deref. The `ArenaVec` is created inside the same proving phase where it was previously copied into one, so arena-phase semantics are unchanged. This matches how `main` already does it; the bug is devnet4-only.

## Results (Zen5, Ryzen 7 9700X, interleaved runs, mean of `--repeat 10`)

| binary | time (s) | XMSS/s | vs pre-merge `c39f0ff` |
| --- | --- | --- | --- |
| pre-merge `c39f0ff` | 0.2964 | 215.9 | — |
| `a44bca4` unpatched | 0.3129 | 204.6 | −5.3% |
| **`a44bca4` + fix** | **0.2900** | **220.7** | **+2.2%** |

Patched trace shows `run_initial_sumcheck_rounds` self time back to 0.00%. Proof size unchanged (265 KiB).

## Testing

- `cargo test -p mt-whir -p sub_protocols --release` passes (incl. end-to-end prove/verify `test_run_whir`)
- `cargo fmt --check` and `cargo clippy -p mt-whir` clean