### PR TITLE
perf(poly): packed split-eq evaluation for base-coefficient multilinears

### DIFF
--- a/crates/backend/poly/src/eq_mle.rs
+++ b/crates/backend/poly/src/eq_mle.rs
@@ -733,7 +733,7 @@ fn eval_eq_with_packed_scalar<F: Field, EF: ExtensionField<F>, const INITIALIZED
             // do a similar strategy in those branches but, those branches should only be hit
             // infrequently in small cases which are already sufficiently fast.
             iter_array_chunks_padded::<_, EVAL_LEN>(EF::ExtensionPacking::to_ext_iter(eq_evaluations), EF::ZERO)
-                .zip(out.chunks_exact_mut(EVAL_LEN))
+                .zip(out.as_chunks_mut::<EVAL_LEN>().0.iter_mut())
                 .for_each(|(res, out_chunk)| {
                     if INITIALIZED {
                         EF::add_slices(out_chunk, &res);

--- a/crates/backend/poly/src/evals.rs
+++ b/crates/backend/poly/src/evals.rs
@@ -1,7 +1,7 @@
 use crate::*;
 use crate::{EFPacking, PF};
 use ::utils::log2_ceil_usize;
-use field::{ExtensionField, Field, PrimeCharacteristicRing};
+use field::{ExtensionField, Field, PackedFieldExtension, PackedValue, PrimeCharacteristicRing};
 use zk_alloc::ArenaVec;
 pub trait EvaluationsList<F: Field> {
     fn num_variables(&self) -> usize;
@@ -110,6 +110,54 @@ where
 //     let res_unpacked: Vec<EF> = unpack_extension(&[res_packed]);
 //     eval_multilinear(&res_unpacked, &point[point.len() - log_width..])
 // }
+
+/// Minimum number of variables for [`eval_base_packed`] to use the split-eq
+/// strategy; below this the recursive strategy is used. Must stay above
+/// `packing_log_width + 1` so both eq tables are non-trivial.
+const EVAL_BASE_PACKED_MIN_VARS: usize = 6;
+
+/// Evaluate a multilinear polynomial with base-field coefficients at an
+/// extension-field point, via the regrouped sum
+///
+/// `Σ_{v_hi} eq(v_hi, p_hi) · (Σ_{v_lo} f(v_hi, v_lo) · eq(v_lo, p_lo))`.
+///
+/// The two eq tables have `~2^{n/2}` entries each, so their construction is
+/// negligible, and the inner dot products run on packed values with cheap
+/// base-times-extension multiplications. The recursive strategy used by
+/// `evaluate` spends one extension-by-extension multiplication per pair of
+/// subtrees, which is several times more base multiplications in total.
+pub fn eval_base_packed<EF, const PARALLEL: bool>(evals: &[PF<EF>], point: &[EF]) -> EF
+where
+    EF: ExtensionField<PF<EF>>,
+{
+    debug_assert_eq!(evals.len(), 1 << point.len());
+    if point.len() < EVAL_BASE_PACKED_MIN_VARS {
+        return eval_multilinear::<_, _, PARALLEL>(evals, point);
+    }
+
+    // The `mid` low-order (fastest-moving) variables go to the inner, contiguous
+    // dot products; `eval_eq_packed` requires more variables than the packing width.
+    let mid = (point.len() / 2).max(packing_log_width::<EF>() + 1);
+    let (hi, lo) = point.split_at(point.len() - mid);
+    let eq_lo = eval_eq_packed(lo);
+    let eq_hi = eval_eq(hi);
+
+    let dot = |i: usize| -> EF {
+        let part = PFPacking::<EF>::pack_slice(&evals[i << mid..][..1 << mid]);
+        let mut acc = EFPacking::<EF>::ZERO;
+        for (&a, &b) in part.iter().zip(eq_lo.iter()) {
+            acc += b * a;
+        }
+        EFPacking::<EF>::to_ext_iter([acc]).sum::<EF>() * eq_hi[i]
+    };
+
+    let work_size: usize = (1 << 15) / std::mem::size_of::<PF<EF>>();
+    if PARALLEL && evals.len() > work_size {
+        parallel::map_reduce(eq_hi.len(), || EF::ZERO, dot, |a, b| a + b)
+    } else {
+        (0..eq_hi.len()).map(dot).sum()
+    }
+}
 
 pub fn eval_packed<EF, const PARALLEL: bool>(evals: &[EFPacking<EF>], point: &[EF]) -> EF
 where
@@ -370,5 +418,28 @@ mod tests {
         println!("Packed eval time: {:?}", time.elapsed());
 
         assert_eq!(res_normal, res_packed);
+    }
+
+    #[test]
+    fn test_eval_base_packed() {
+        let mut rng = StdRng::seed_from_u64(0);
+        for n_vars in 0..=18 {
+            let poly = (0..(1usize << n_vars))
+                .map(|_| rng.random())
+                .collect::<Vec<koala_bear::KoalaBear>>();
+            let point = (0..n_vars).map(|_| rng.random()).collect::<Vec<EF>>();
+
+            let expected = eval_multilinear::<_, _, false>(&poly, &point);
+            assert_eq!(
+                eval_base_packed::<EF, false>(&poly, &point),
+                expected,
+                "n_vars = {n_vars}"
+            );
+            assert_eq!(
+                eval_base_packed::<EF, true>(&poly, &point),
+                expected,
+                "n_vars = {n_vars}"
+            );
+        }
     }
 }

--- a/crates/backend/poly/src/mle/mle_single_ref.rs
+++ b/crates/backend/poly/src/mle/mle_single_ref.rs
@@ -80,9 +80,9 @@ impl<'a, EF: ExtensionField<PF<EF>>> MleRef<'a, EF> {
 
     pub fn evaluate(&self, point: &MultilinearPoint<EF>) -> EF {
         match self {
-            Self::Base(pol) => pol.evaluate(point),
+            Self::Base(pol) => eval_base_packed::<EF, true>(pol, &point.0),
             Self::Extension(pol) => pol.evaluate(point),
-            Self::BasePacked(pol) => PFPacking::<EF>::unpack_slice(pol).evaluate(point),
+            Self::BasePacked(pol) => eval_base_packed::<EF, true>(PFPacking::<EF>::unpack_slice(pol), &point.0),
             Self::ExtensionPacked(pol) => eval_packed::<_, true>(pol, &point.0),
         }
     }

--- a/crates/backend/symetric/src/sponge.rs
+++ b/crates/backend/symetric/src/sponge.rs
@@ -17,7 +17,7 @@ where
     debug_assert!(data.len().is_multiple_of(RATE));
     let mut state = [T::default(); WIDTH];
     state[0] = T::from_usize(data.len());
-    for chunk in data.chunks_exact(RATE).rev() {
+    for chunk in data.as_chunks::<RATE>().0.iter().rev() {
         state[WIDTH - RATE..].copy_from_slice(chunk);
         perm.permute_mut(&mut state);
     }

--- a/crates/lean_vm/src/tables/poseidon/trace_gen.rs
+++ b/crates/lean_vm/src/tables/poseidon/trace_gen.rs
@@ -55,7 +55,7 @@ pub(super) fn generate_trace_rows_for_perm<F: Algebra<KoalaBear> + Copy>(perm: &
     for (full_round, constants) in perm
         .beginning_full_rounds
         .iter_mut()
-        .zip(poseidon1_initial_constants().chunks_exact(2))
+        .zip(poseidon1_initial_constants().as_chunks::<2>().0.iter())
     {
         generate_2_full_round(&mut state, full_round, &constants[0], &constants[1]);
     }
@@ -99,7 +99,7 @@ pub(super) fn generate_trace_rows_for_perm<F: Algebra<KoalaBear> + Copy>(perm: &
     for (full_round, constants) in perm
         .ending_full_rounds
         .iter_mut()
-        .zip(poseidon1_final_constants().chunks_exact(2))
+        .zip(poseidon1_final_constants().as_chunks::<2>().0.iter())
     {
         generate_2_full_round(&mut state, full_round, &constants[0], &constants[1]);
     }

--- a/crates/sub_protocols/src/logup.rs
+++ b/crates/sub_protocols/src/logup.rs
@@ -245,14 +245,14 @@ pub fn prove_generic_logup(
 
     // Memory: ...
     let memory_and_acc_point = MultilinearPoint(from_end(&claim_point_gkr, log2_strict_usize(memory.len())).to_vec());
-    let value_memory_acc = memory_acc.evaluate(&memory_and_acc_point);
+    let value_memory_acc = eval_base_packed::<EF, true>(memory_acc, &memory_and_acc_point.0);
     prover_state.add_extension_scalar(value_memory_acc);
 
-    let value_memory = memory.evaluate(&memory_and_acc_point);
+    let value_memory = eval_base_packed::<EF, true>(memory, &memory_and_acc_point.0);
     prover_state.add_extension_scalar(value_memory);
 
     let bytecode_and_acc_point = MultilinearPoint(from_end(&claim_point_gkr, log_bytecode).to_vec());
-    let value_bytecode_acc = bytecode_acc.evaluate(&bytecode_and_acc_point);
+    let value_bytecode_acc = eval_base_packed::<EF, true>(bytecode_acc, &bytecode_and_acc_point.0);
     prover_state.add_extension_scalar(value_bytecode_acc);
 
     // evaluation on bytecode itself can be done directly by the verifier
@@ -269,8 +269,10 @@ pub fn prove_generic_logup(
 
         let resolve_ef = |entry: BusData| -> EF {
             match entry {
-                BusData::Column(col) => trace.columns[col].evaluate(&inner_point),
-                BusData::ColumnPlusConstant(col, ofs) => trace.columns[col].evaluate(&inner_point) + F::from_usize(ofs),
+                BusData::Column(col) => eval_base_packed::<EF, true>(&trace.columns[col], &inner_point.0),
+                BusData::ColumnPlusConstant(col, ofs) => {
+                    eval_base_packed::<EF, true>(&trace.columns[col], &inner_point.0) + F::from_usize(ofs)
+                }
                 BusData::Constant(val) => EF::from_usize(val),
             }
         };
@@ -278,8 +280,8 @@ pub fn prove_generic_logup(
         for bus in table.bus_interactions() {
             match bus.multiplicity {
                 BusMultiplicity::Column(mult_col) => {
-                    let eval_on_multiplicity =
-                        trace.columns[mult_col].evaluate(&inner_point) * bus.direction.to_field_flag();
+                    let eval_on_multiplicity = eval_base_packed::<EF, true>(&trace.columns[mult_col], &inner_point.0)
+                        * bus.direction.to_field_flag();
                     prover_state.add_extension_scalar(eval_on_multiplicity);
                     let data_evals: Vec<EF> = bus.data.iter().map(|e| resolve_ef(*e)).collect();
                     let eval_on_data = c - finger_print(resolve_ef(bus.domainsep), &data_evals, alphas_eq_poly);
@@ -298,7 +300,7 @@ pub fn prove_generic_logup(
                         .filter_map(|entry| {
                             entry.column().and_then(|col| {
                                 if let std::collections::btree_map::Entry::Vacant(e) = table_values.entry(col) {
-                                    let v = trace.columns[col].evaluate(&inner_point);
+                                    let v = eval_base_packed::<EF, true>(&trace.columns[col], &inner_point.0);
                                     e.insert(v);
                                     Some(v)
                                 } else {

--- a/crates/xmss/src/lib.rs
+++ b/crates/xmss/src/lib.rs
@@ -48,8 +48,8 @@ pub(crate) fn poseidon_prf(domain: u32, seed: &[u8; 32], indices: [usize; 2]) ->
     input[0] = F::from_u32(domain);
     let mask: usize = (1 << 30) - 1;
     let mut high_bits = 0usize;
-    for (i, word) in seed.chunks_exact(4).enumerate() {
-        let w = u32::from_le_bytes(word.try_into().unwrap()) as usize;
+    for (i, word) in seed.as_chunks::<4>().0.iter().enumerate() {
+        let w = u32::from_le_bytes(*word) as usize;
         input[1 + i] = F::from_usize(w & mask);
         high_bits |= (w >> 30) << (2 * i);
     }

--- a/crates/xmss/src/wots.rs
+++ b/crates/xmss/src/wots.rs
@@ -165,7 +165,9 @@ pub fn wots_encode(
         .iter()
         .flat_map(|kb| to_little_endian_bits(kb.to_usize(), 24))
         .collect::<Vec<_>>()
-        .chunks_exact(W)
+        .as_chunks::<W>()
+        .0
+        .iter()
         .take(V)
         .map(|chunk| {
             chunk

--- a/crates/xmss/src/xmss.rs
+++ b/crates/xmss/src/xmss.rs
@@ -57,8 +57,8 @@ impl XmssPublicKey {
 fn gen_wots_secret_key(seed: &[u8; 32], slot: u32, public_param: PublicParam) -> WotsSecretKey {
     let rng_seed_fe = poseidon_prf(PRF_DOMAINSEP_WOTS_SECRET_KEY, seed, [slot as usize, 0]);
     let mut rng_seed = [0u8; 32];
-    for (chunk, f) in rng_seed.chunks_exact_mut(4).zip(rng_seed_fe) {
-        chunk.copy_from_slice(&f.as_canonical_u32().to_le_bytes());
+    for (chunk, f) in rng_seed.as_chunks_mut::<4>().0.iter_mut().zip(rng_seed_fe) {
+        *chunk = f.as_canonical_u32().to_le_bytes();
     }
     let mut rng = StdRng::from_seed(rng_seed);
     WotsSecretKey::random(&mut rng, public_param, slot)


### PR DESCRIPTION
## What

Evaluating a base-field multilinear at an extension-field point (WHIR commitment OOD answers, logup statement openings) goes through the recursive strategy, which spends one EF x EF multiplication per pair of subtrees, about `2^(n-1)` of them for `n` variables. In the XMSS aggregation workload these evaluations take ~2.7% of prover CPU time; the largest single site is the OOD evaluation of the `2^27` base polynomial in `WhirConfig::commit`.

Root cause: `MleRef::{Base, BasePacked}::evaluate` and the logup statement openings cannot exploit base-field, contiguous coefficients through the generic recursion.

Fix: add `eval_base_packed`, which computes the regrouped sum

```text
sum_hi eq(hi) * ( sum_lo f(hi, lo) * eq(lo) )
```

with two eq tables of `~2^(n/2)` entries each (construction negligible, built with the existing `eval_eq_packed` / `eval_eq`) and packed base-times-extension dot products for the inner sums. `MleRef::{Base, BasePacked}` and the logup prover openings are routed through it; below 6 variables it falls back to the recursion.

Note on the commented-out `eval_multilinear_packed_base` ("turns out to be slower"): that experiment vectorized the recursion itself, so it kept the `O(2^n)` extension-multiplication structure. The split-eq form changes the multiplication mix (almost everything becomes packed base-times-extension), not just the lanes, which is where the win comes from.

The dispatch lives at the call sites rather than inside `eval_multilinear` because the generic `F: Field` there does not carry the `EF: ExtensionField<PF<EF>>` bound the packed types need; `eval_base_packed` sits next to `eval_packed`, which has the same bound.

## Numbers

Apple M3 Pro (aarch64 NEON), `xmss --n-signatures 1550 --log-inv-rate 1`:

| measurement | main | this PR |
| --- | --- | --- |
| eval, n=12 vars | 17.3us | 5.0us (3.4x) |
| eval, n=18 vars | 158.3us | 97.5us (1.6x) |
| eval, n=22 vars | 1419.7us | 735.8us (1.9x) |
| prover CPU share of these evals (perf) | 2.67% | 0.93% |

End-to-end throughput moves consistently with the ~1.7% CPU saving (interleaved A/B runs averaged roughly +2%), but that is within my machine's run-to-run noise, so I am only claiming the CPU-share numbers.

```text
repro:
cargo test --release -p poly test_eval_base_packed
cargo run --release -- xmss --n-signatures 1550 --log-inv-rate 1
```

## Correctness

- Proof bytes are unchanged: `dump_test_vectors_for_python_verifier` produces byte-identical vectors on all 5 sweep configs against main (only the summation order differs, and field arithmetic is exact).
- New `test_eval_base_packed` compares the packed path against the recursive one for n = 0..=18, parallel and sequential.
- Full workspace suite passes (56 tests), clippy and fmt clean, `cargo check` for x86_64 and x86_64 + avx2 clean.

## Scope

- Only base-coefficient evaluations at extension points are re-routed (`MleRef::Base`, `MleRef::BasePacked`, logup prover statement openings).
- `MleRef::Extension{,Packed}`, `eval_packed`, and the recursion below 6 variables are untouched.
- The `>= 20` scalar split-eq branch inside `eval_multilinear_generic` is left as is; it still serves extension-coefficient slices.
