### PR TITLE
fix(poly): drop wrong packing-width assert on the middle eval slice

### DIFF
--- a/crates/backend/field/src/packed/packed_traits.rs
+++ b/crates/backend/field/src/packed/packed_traits.rs
@@ -337,7 +337,6 @@ pub trait PackedFieldExtension<BaseField: Field, ExtField: ExtensionField<BaseFi
 
     /// Unpack one packed element into the `BaseField::Packing::WIDTH` extension field elements
     /// it holds. Use `.flat_map(Self::to_ext_lanes)` to unpack an iterator of packed elements.
-    #[must_use]
     fn to_ext_lanes(self) -> impl Iterator<Item = ExtField>;
 
     /// Given a iterator of packed extension field elements, convert to an iterator of
@@ -360,7 +359,6 @@ pub trait PackedFieldExtension<BaseField: Field, ExtField: ExtensionField<BaseFi
     /// Note that the length of the returned iterator will be `unpacked_len / WIDTH` and
     /// not `len` as the iterator is over packed extension field elements. If `unpacked_len`
     /// is not divisible by `WIDTH`, `unpacked_len` will be rounded up to the next multiple of `WIDTH`.
-    #[must_use]
     fn packed_ext_powers_capped(base: ExtField, unpacked_len: usize) -> impl Iterator<Item = Self> {
         Self::packed_ext_powers(base).take(unpacked_len.div_ceil(BaseField::Packing::WIDTH))
     }

--- a/crates/backend/poly/src/eq_mle.rs
+++ b/crates/backend/poly/src/eq_mle.rs
@@ -1021,14 +1021,8 @@ fn base_eval_eq_packed_with_packed_output<F, EF, const INITIALIZED: bool>(
     F: Field,
     EF: ExtensionField<F>,
 {
-    // Ensure that the output buffer size is correct:
-    // It should be of size `2^n`, where `n` is the number of variables.
-    //
-    // `eval_points` is the *middle* slice handed over by `par_eval_eq`, not the full point:
-    // the `log_packing_width` suffix is already folded into `eq_evals` and the `log_chunks`
-    // prefix into `packed_scalar`. Its length is therefore unrelated to the packing width,
-    // and asserting `log_packing_width <= eval_points.len()` here is wrong — that invariant
-    // belongs to the callers, which check it against the *full* point.
+    // `eval_points` is the middle slice from `par_eval_eq`, so its length says nothing about the
+    // packing width (the callers assert that against the full point).
     debug_assert_eq!(out.len(), 1 << eval_points.len());
 
     match eval_points.len() {
@@ -1323,35 +1317,26 @@ mod tests {
         }
     }
 
-    /// `base_eval_eq_packed_with_packed_output` receives the *middle* slice of the eval
-    /// points: `par_eval_eq` strips a `log_chunks` prefix and a `log_packing_width` suffix,
-    /// leaving `n - log_packing_width - log_chunks` variables. The packed path only requires
-    /// that to be at least 2, so the middle slice is routinely *shorter* than
-    /// `log_packing_width` and the kernel must not assume otherwise.
-    ///
-    /// This covers the narrow band of `n_vars` just above the packed-path threshold, where
-    /// that happens. Both the assertion and the band are machine-dependent (they move with
-    /// the thread count and SIMD width), so the bounds are computed rather than hardcoded.
+    /// `par_eval_eq` hands the kernel a middle slice of any length >= 2, so the hardcoded arms
+    /// below `log_packing_width` must agree with the unpacked-output twin. Calling the kernel
+    /// directly keeps this independent of the SIMD width and thread count.
     #[test]
-    fn base_packed_handles_middle_slice_shorter_than_packing_width() {
-        let log_packing_width = log2_strict_usize(<F as Field>::Packing::WIDTH);
-        let (log_chunks, _) = parallel_split();
+    fn base_packed_kernel_handles_short_slices() {
         let mut rng = StdRng::seed_from_u64(11);
+        let scalar: EF = rng.random();
+        let eq_evals = <F as Field>::Packing::from_fn(|_| rng.random());
 
-        // Lower bound: first `n_vars` taking the packed path (see `compute_eval_eq_base_packed`).
-        // Upper bound: first `n_vars` whose middle slice reaches `log_packing_width`.
-        for n_vars in (log_packing_width + log_chunks + 2)..=(2 * log_packing_width + log_chunks) {
-            let eval: Vec<F> = (0..n_vars).map(|_| rng.random()).collect();
-            let scalar: EF = rng.random();
+        for len in 1..=3 {
+            let points: Vec<F> = (0..len).map(|_| rng.random()).collect();
 
-            let mut expected = EF::zero_vec(1 << n_vars);
-            compute_eval_eq_base::<F, EF, true>(&eval, &mut expected, scalar);
+            let mut expected = EF::zero_vec(<F as Field>::Packing::WIDTH << len);
+            base_eval_eq_packed::<F, EF, false>(&points, &mut expected, eq_evals, scalar);
 
-            let mut packed = <EF as ExtensionField<F>>::ExtensionPacking::zero_vec(1 << (n_vars - log_packing_width));
-            compute_eval_eq_base_packed::<F, EF, true>(&eval, &mut packed, scalar);
+            let mut packed = EFPacking::<EF>::zero_vec(1 << len);
+            let packed_scalar = EFPacking::<EF>::from(scalar);
+            base_eval_eq_packed_with_packed_output::<F, EF, false>(&points, &mut packed, eq_evals, packed_scalar);
 
-            let unpacked: Vec<EF> = <EF as ExtensionField<F>>::ExtensionPacking::to_ext_iter_vec(packed);
-            assert_eq!(expected, unpacked, "n_vars = {n_vars}");
+            assert_eq!(expected, EFPacking::<EF>::to_ext_iter_vec(packed), "len = {len}");
         }
     }
 

--- a/crates/backend/poly/src/eq_mle.rs
+++ b/crates/backend/poly/src/eq_mle.rs
@@ -1023,10 +1023,13 @@ fn base_eval_eq_packed_with_packed_output<F, EF, const INITIALIZED: bool>(
 {
     // Ensure that the output buffer size is correct:
     // It should be of size `2^n`, where `n` is the number of variables.
-    let width = F::Packing::WIDTH;
-    let log_packing_width = log2_strict_usize(width);
+    //
+    // `eval_points` is the *middle* slice handed over by `par_eval_eq`, not the full point:
+    // the `log_packing_width` suffix is already folded into `eq_evals` and the `log_chunks`
+    // prefix into `packed_scalar`. Its length is therefore unrelated to the packing width,
+    // and asserting `log_packing_width <= eval_points.len()` here is wrong — that invariant
+    // belongs to the callers, which check it against the *full* point.
     debug_assert_eq!(out.len(), 1 << eval_points.len());
-    debug_assert!(log_packing_width <= eval_points.len());
 
     match eval_points.len() {
         0 => {
@@ -1317,6 +1320,38 @@ mod tests {
 
                 assert_eq!(out_2, out_3_packed);
             }
+        }
+    }
+
+    /// `base_eval_eq_packed_with_packed_output` receives the *middle* slice of the eval
+    /// points: `par_eval_eq` strips a `log_chunks` prefix and a `log_packing_width` suffix,
+    /// leaving `n - log_packing_width - log_chunks` variables. The packed path only requires
+    /// that to be at least 2, so the middle slice is routinely *shorter* than
+    /// `log_packing_width` and the kernel must not assume otherwise.
+    ///
+    /// This covers the narrow band of `n_vars` just above the packed-path threshold, where
+    /// that happens. Both the assertion and the band are machine-dependent (they move with
+    /// the thread count and SIMD width), so the bounds are computed rather than hardcoded.
+    #[test]
+    fn base_packed_handles_middle_slice_shorter_than_packing_width() {
+        let log_packing_width = log2_strict_usize(<F as Field>::Packing::WIDTH);
+        let (log_chunks, _) = parallel_split();
+        let mut rng = StdRng::seed_from_u64(11);
+
+        // Lower bound: first `n_vars` taking the packed path (see `compute_eval_eq_base_packed`).
+        // Upper bound: first `n_vars` whose middle slice reaches `log_packing_width`.
+        for n_vars in (log_packing_width + log_chunks + 2)..=(2 * log_packing_width + log_chunks) {
+            let eval: Vec<F> = (0..n_vars).map(|_| rng.random()).collect();
+            let scalar: EF = rng.random();
+
+            let mut expected = EF::zero_vec(1 << n_vars);
+            compute_eval_eq_base::<F, EF, true>(&eval, &mut expected, scalar);
+
+            let mut packed = <EF as ExtensionField<F>>::ExtensionPacking::zero_vec(1 << (n_vars - log_packing_width));
+            compute_eval_eq_base_packed::<F, EF, true>(&eval, &mut packed, scalar);
+
+            let unpacked: Vec<EF> = <EF as ExtensionField<F>>::ExtensionPacking::to_ext_iter_vec(packed);
+            assert_eq!(expected, unpacked, "n_vars = {n_vars}");
         }
     }
 


### PR DESCRIPTION
(Not reviewed yet, working on another branch and pulled out this fix)